### PR TITLE
Doc search via Algolia

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -147,6 +147,14 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      algolia: {
+        appId: '89KSB43UFT',  
+        // Public API key: it is safe to commit it
+        apiKey: 'a0740f141135937727389d897f51fb56',
+        indexName: 'turnkey',
+        contextualSearch: true,
+        searchPagePath: false,  
+      },
     }),
 };
 


### PR DESCRIPTION
Our application was approved 🎉 

This PR enables the search widget. It looks like this:
<img width="360" alt="image" src="https://github.com/tkhq/docs/assets/104520680/1dead6e7-8213-4768-b864-9ca4dfe8bcdb">
...and results in a popup when clicked:
<img width="360" alt="image" src="https://github.com/tkhq/docs/assets/104520680/eb70406e-b947-4e1e-8c66-d8591fb40dcb">

