### PR TITLE
Fix documentation for sub-org wallet creation

### DIFF
--- a/static/specs/services/coordinator/public/v1/public_api.swagger.json
+++ b/static/specs/services/coordinator/public/v1/public_api.swagger.json
@@ -3711,9 +3711,8 @@
       "type": "object",
       "properties": {
         "limit": {
-          "type": "integer",
-          "format": "int32",
-          "description": "A limit of the number of object to be returned, between 1 and 100. Defaults to 10 if omitted or set to 0."
+          "type": "string",
+          "description": "A limit of the number of object to be returned, between 1 and 100. Defaults to 10."
         },
         "before": {
           "type": "string",


### PR DESCRIPTION
Feedback from a customer. Docs were referencing the wrong (deprecated) helpers. Also noticed that we still talk about CORS not being open: this isn't a thing anymore!