### PR TITLE
Fix spelling

### DIFF
--- a/api/public_api.swagger.json
+++ b/api/public_api.swagger.json
@@ -458,7 +458,7 @@
     "/public/v1/query/list_wallet_accounts": {
       "post": {
         "summary": "List Wallets Accounts",
-        "description": "List all Accounts wirhin a Wallet",
+        "description": "List all Accounts within a Wallet",
         "operationId": "GetWalletAccounts",
         "responses": {
           "200": {


### PR DESCRIPTION
Fix spelling of "within" in list wallet accounts api description.