### PR TITLE
policy engine updates

### DIFF
--- a/docs/policy-management/Policy-examples.md
+++ b/docs/policy-management/Policy-examples.md
@@ -127,3 +127,13 @@ slug: /managing-policies/examples
   "condition": "eth.tx.chain_id == 11155111"
 }
 ```
+
+#### Allow ETH transactions with a specific nonce range
+
+```json JSON
+{
+  "policyName": "Allow signing Ethereum transactions with an early nonce",
+  "effect": "EFFECT_ALLOW",
+  "condition": "eth.tx.nonce <= 3"
+}
+```

--- a/docs/policy-management/Policy-language.md
+++ b/docs/policy-management/Policy-language.md
@@ -56,7 +56,7 @@ The language is strongly typed which makes policies easy to author and maintain.
 | Type         | Example       | Notes                                          |
 | ------------ | ------------- | ---------------------------------------------- |
 | **bool**     | true          |                                                |
-| **int**      | 256           | i64                                            |
+| **int**      | 256           | i128                                           |
 | **string**   | 'a'           | only single quotes are supported               |
 | **list<T\>** | [1, 2, 3]     | a list of type T                               |
 | **struct**   | { id: 'abc' } | a key-value map of { field:T } (defined below) |
@@ -82,6 +82,7 @@ The language is strongly typed which makes policies easy to author and maintain.
 |                         | gas       | int           | The maximum allowed gas for the transaction                                  |
 |                         | gas_price | int           | The price of gas for the transaction                                         |
 |                         | chain_id  | int           | The chain identifier for the transaction                                     |
+|                         | nonce     | int           | The nonce for the transaction                                                |
 
 ## Activity Breakdown
 


### PR DESCRIPTION
$title -- context for changes
1. bug fix for tokensight requiring a change from i64 to i128 (for parsing tx values > ~9.22 ETH, or `0x7FFFFFFFFFFFFFFF`)
2. adding nonce handling to our policy engine