### PR TITLE
fix stamp docs

### DIFF
--- a/docs/api-design/stamps.md
+++ b/docs/api-design/stamps.md
@@ -10,8 +10,8 @@ Every request made to Turnkey must include a signature over the POST body attach
 
 ### API Keys
 To create a valid, API key stamped request follow these steps:
-1. SHA256 hash the JSON-encoded POST body
-2. Sign the hash with your API key to produce a `signature`
+1. Sign the JSON-encoded POST body with your API key to produce a `signature` (DER-encoded)
+2. Hex encode the `signature`
 3. Create a JSON-encoded stamp:
     - `publicKey`: the public key of API key
     - `signature`: the signature produced by the API key


### PR DESCRIPTION
helped someone in Club Turnkey get this working in Rust. Turns out our docs were wrong. Whoops!

```
    pub fn stamp(&self, message: &str) -> TurnkeyResult<String> {
        let private_api_key_bytes = hex_to_bytes(&self.api_private_key).unwrap();
        let signing_key = SigningKey::from_bytes(&private_api_key_bytes).unwrap();

        let signature = signing_key.sign(message.as_bytes());
        let signature_der = signature.to_der().to_bytes();
        let signature_hex = bytes_to_hex(&signature_der).unwrap();

        let stamp = ApiStamp {
            public_key: self.api_public_key.to_string(),
            signature: signature_hex,
            scheme: "SIGNATURE_SCHEME_TK_API_P256".into(),
        };

        let json_stamp = serde_json::to_string(&stamp).unwrap();
        let encoded_stamp = base64_url::encode(json_stamp.as_bytes());

        Ok(encoded_stamp)
    }
```