### PR TITLE
Minor: Rename gen api key CLI command

### DIFF
--- a/docs/getting-started/Quickstart.md
+++ b/docs/getting-started/Quickstart.md
@@ -45,7 +45,7 @@ We are employing [Homebrew](https://brew.sh/) in this guide as a quick and easy 
 #### Generate an API key
 
 ```sh
-turnkey generate-api-key --organization $ORGANIZATION_ID --key-name quickstart
+turnkey generate api-key --organization $ORGANIZATION_ID --key-name quickstart
 ```
 
 When you run this command, Turnkey’s CLI generates an API key pair and **stores the API private key locally**. Copy the `publicKey` field in the output. In the next step, we'll add this to our User.

--- a/docs/policy-management/Policy-quickstart.md
+++ b/docs/policy-management/Policy-quickstart.md
@@ -26,7 +26,7 @@ In the create user flow, you have the option to grant API key or web access to y
 Under access types, select "API key". Enter the user name "Policy Test". This will be an API-only user, and therefore an email is not required.  Click continue and create a new API key to associate with the user using the following command:
 
 ```shell
-turnkey generate-api-key --organization $ORGANIZATION_ID --key-name policy_test
+turnkey generate api-key --organization $ORGANIZATION_ID --key-name policy_test
 ```
 
 This will create 2 files, "policy_test.public" and "policy_test.private". Copy the contents of the ".public" file and paste it into "API public key". Finish the create user flow and authenticate. Your new user will appear in the Users table. Note down the user ID as you will use it in the next step.


### PR DESCRIPTION
Rename `generate-api-key` -> `generate api-key` for Turnkey CLI commands in quickstart and policy guide