### PR TITLE
Add `vercel.json` file to handle recent URL updates gracefully (with redirects)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,8 +6,8 @@
       "permanent": true
     },
     {
-      "source": "/api-design/*",
-      "destination": "/api-overview/*", 
+      "source": "/api-design/:page",
+      "destination": "/api-overview/:page", 
       "permanent": true
     },
     {
@@ -16,8 +16,8 @@
       "permanent": true
     },
     {
-      "source": "/managing-policies/*",
-      "destination": "/concepts/policies/*", 
+      "source": "/managing-policies/:page",
+      "destination": "/concepts/policies/:page", 
       "permanent": true
     },
     {


### PR DESCRIPTION
The idea is to have server-side redirects in place for old URLs to avoid 404s if these URLs are hardcoded in docs, emails, slack messages, PDFs and whatnot.

I went through all changes (I think?) from #111 but let me know if I missed anything. Also, this isn't about being exhaustive. Just wanted to put this in place so we have a pattern for future URL updates!

Example: https://docs-git-rno-verceljson-turnkey.vercel.app/getting-started/email-auth works and redirects to https://docs-git-rno-verceljson-turnkey.vercel.app/features/email-auth

...whereas https://docs.turnkey.com/getting-started/email-auth 404s right now 😭  (which is the topic of [this issue](https://github.com/tkhq/sdk/issues/273) -- luckily this was fixable!)