### PR TITLE
managing-users -> concepts/users

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,11 @@
       "permanent": true
     },
     {
+      "source": "/managing-users/:page",
+      "destination": "/concepts/users/:page",
+      "permanent": true
+    },
+    {
       "source": "/users/best-practice",
       "destination": "/concepts/users/best-practice",
       "permanent": true


### PR DESCRIPTION
Noticed by a candidate!

The "Root Quorum" link on https://docs.turnkey.com/api is a dead link. It goes to https://docs.turnkey.com/managing-users/root-quorum, which 404s.

This PR adds a redirect so this link works!

I'll (separately) update our swagger spec in mono to have the right link to start with. Putting this redirect in place will make sure any user who has the old page bookmarked somehow is correctly redirected instead of faced with a 404.

The link on https://docs-git-rno-fix-api-doc-link-turnkey.vercel.app/api works 🎉 