### PR TITLE
Fix changelog link to blog post

### DIFF
--- a/docs/changelog/changelog.mdx
+++ b/docs/changelog/changelog.mdx
@@ -23,7 +23,7 @@ Our [OAuth](https://docs.turnkey.com/features/oauth) feature is now live and out
 - Sign in and authentication via popular providers such as Google, Apple, and Facebook (via OpenID Connect tokens) for organizations and sub-organizations
 - Custom OAuth configurations for your organizations or sub-organizations
 
-All OIDC tokens are verified via Turnkey's secure enclaves, with a newly designed enclave to [fetch TLS content](https://quorum.tkhq.xyz/posts/tls-sessions-within-tees/0).
+All OIDC tokens are verified via Turnkey's secure enclaves, with a newly designed enclave to [fetch TLS content](https://quorum.tkhq.xyz/posts/tls-sessions-within-tees).
 
 ## 2024-08-15
 


### PR DESCRIPTION
Removed the `/0` suffix which made the link 404