### PR TITLE
chore: update sdk-browser and sdk-server docs with sessions

### DIFF
--- a/api/public_api.swagger.json
+++ b/api/public_api.swagger.json
@@ -3342,6 +3342,10 @@
         "expirationSeconds": {
           "type": "string",
           "description": "Expiration window (in seconds) indicating how long the API key is valid. If not provided, a default of 15 minutes will be used."
+        },
+        "invalidateExisting": {
+          "type": "boolean",
+          "description": "Invalidate all other previously generated ReadWriteSession API keys"
         }
       },
       "required": ["targetPublicKey"]
@@ -4041,7 +4045,9 @@
         "CREDENTIAL_TYPE_API_KEY_SECP256K1",
         "CREDENTIAL_TYPE_EMAIL_AUTH_KEY_P256",
         "CREDENTIAL_TYPE_API_KEY_ED25519",
-        "CREDENTIAL_TYPE_OTP_AUTH_KEY_P256"
+        "CREDENTIAL_TYPE_OTP_AUTH_KEY_P256",
+        "CREDENTIAL_TYPE_READ_WRITE_SESSION_KEY_P256",
+        "CREDENTIAL_TYPE_OAUTH_KEY_P256"
       ]
     },
     "Curve": {
@@ -6215,6 +6221,10 @@
         "expirationSeconds": {
           "type": "string",
           "description": "Expiration window (in seconds) indicating how long the API key is valid. If not provided, a default of 15 minutes will be used."
+        },
+        "invalidateExisting": {
+          "type": "boolean",
+          "description": "Invalidate all other previously generated Oauth API keys"
         }
       },
       "required": ["oidcToken", "targetPublicKey"]

--- a/docs/sdks/javascript-browser.mdx
+++ b/docs/sdks/javascript-browser.mdx
@@ -316,7 +316,7 @@ An existing session to authenticate the user with.
 
 ### `loginWithWallet()`
 
-Login with awallet
+Login with an existing wallet e.g. Metamask
 
 #### Parameters
 

--- a/docs/sdks/javascript-browser.mdx
+++ b/docs/sdks/javascript-browser.mdx
@@ -55,7 +55,7 @@ const turnkey = new Turnkey({
     name: 'config',
     type: {
       name: 'TurnkeySDKBrowserConfig',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L83'
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L96'
     }
   }}
   isRequired
@@ -150,6 +150,314 @@ const browserClient = new TurnkeyBrowserClient(config);
 const readOnlySession = await browserClient.login({ organizationId: "org-id" });
 ```
 
+### `loginWithBundle()`
+
+Authenticate a user via the credential bundle emailed to them and creates a read-write session
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'params',
+    type: {
+      name: 'LoginWithBundleParams',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L219'
+    }
+  }}
+  isRequired
+>
+An object containing the parameters to authenticate via a Passkey.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'bundle',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The credential bundle string emailed to the user.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'expirationSeconds',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+The public key of the target user. This will be inferred from the `TurnkeyIframeClient` if `targetPublicKey` is not provided.
+
+</Parameter>
+
+</Parameter>
+
+### `loginWithPasskey()`
+
+Authenticate a user via Passkey and create a read-only or read-write session
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'params',
+    type: {
+      name: 'LoginWithPasskeyParams',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L224'
+    }
+  }}
+  isRequired
+>
+An object containing the parameters to authenticate via a Passkey.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionType',
+    type: {
+      name: 'SessionType',
+    }
+  }}
+  isRequired
+>
+
+The type of session to be created. Either read-only or read-write.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'iframeClient',
+    type: {
+      name: 'TurnkeyIframeClient',
+    }
+  }}
+  isRequired
+>
+
+An instance of a `TurnkeyIframeClient`
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'expirationSeconds',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+The public key of the target user. This will be inferred from the `TurnkeyIframeClient` if `targetPublicKey` is not provided.
+
+</Parameter>
+
+</Parameter>
+
+### `loginWithSession()`
+
+Log in with a session object created via a server action. The session can be either read-only or read-write.
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'session',
+    type: {
+      name: 'Session',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L25'
+    }
+  }}
+  isRequired
+>
+An existing session to authenticate the user with.
+
+</Parameter>
+
+### `loginWithWallet()`
+
+Login with awallet
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'params',
+    type: {
+      name: 'LoginWithWalletParams',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L231'
+    }
+  }}
+  isRequired
+>
+An object containing the parameters to authenticate via a browser wallet.
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionType',
+    type: {
+      name: 'SessionType',
+    }
+  }}
+  isRequired
+>
+
+The type of session to be created. Either read-only or read-write.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'iframeClient',
+    type: {
+      name: 'TurnkeyIframeClient',
+    }
+  }}
+  isRequired
+>
+
+An instance of a `TurnkeyIframeClient`
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'expirationSeconds',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+The public key of the target user. This will be inferred from the `TurnkeyIframeClient` if `targetPublicKey` is not provided.
+
+</Parameter>
+
+</Parameter>
+
+### `refreshSession()`
+
+Attempts to refresh an existing, active session and will extend the session expiry using the `expirationSeconds` parameter
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'request',
+    type: {
+      name: 'RefreshSessionParams',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L213'
+    }
+  }}
+  isRequired
+>
+
+An object containing the `RefreshSessionParams`.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionType',
+    type: {
+      name: 'SessionType',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L20'
+    }
+  }}
+  isRequired
+>
+
+The type of `Session` that is being refreshed.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'expirationSeconds',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Specify how long to extend the session. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+The public key of the target user. This will be inferred from the `TurnkeyIframeClient` if `targetPublicKey` is not provided.
+
+</Parameter>
+
+</Parameter>
+
 ### `loginWithReadWriteSession()`
 
 Creates a read-write session. This method infers the current user's organization ID and target userId. To be used in conjunction with an `iframeStamper`: the resulting session's credential bundle can be injected into an iframeStamper to create a session that enables both read and write requests.
@@ -175,7 +483,7 @@ const readWriteSession = await browserClient.loginWithReadWriteSession(
 
 ## TurnkeyPasskeyClient
 
-The `TurnkeyPasskeyClient` class extends `TurnkeyBrowserClient` and specializes it for user authentication through passkeys, which leverage the WebAuthn standard for passwordless authentication. This class enables the implementation of strong, user-friendly authentication experiences in a web-based application without relying on passwords. TurnkeyPasskeyClient handles passkey creation, session management with passkeys and integrates with WebAuthn and Embedded API Keys.
+The `TurnkeyPasskeyClient` class extends `TurnkeyBrowserClient` and specializes it for user authentication through Passkeys, which leverage the WebAuthn standard for passwordless authentication. This class enables the implementation of strong, user-friendly authentication experiences in a web-based application without relying on passwords. TurnkeyPasskeyClient handles passkey creation, session management with passkeys and integrates with WebAuthn and Embedded API Keys.
 
 To see how to instantiate the `TurnkeyPasskeyClient`, [look here](#passkeyclient)
 
@@ -183,7 +491,7 @@ Below are the methods exposed by the `TurnkeyPasskeyClient`
 
 ### `createUserPasskey()`
 
-Creates a passkey for an end-user, handling lower-level configurations for the WebAuthn protocol, including challenges and user details. For more detailed examples using this method [look here](/embedded-wallets/code-examples/add-credential).
+Creates a Passkey for an end-user, handling lower-level configurations for the WebAuthn protocol, including challenges and user details. For more detailed examples using this method [look here](/embedded-wallets/code-examples/add-credential).
 
 ```typescript
 import { Turnkey } from "@turnkey/sdk-browser";
@@ -210,7 +518,7 @@ const passkey = await passkeyClient.createUserPasskey({
 
 ### `createPasskeySession()`
 
-Uses passkey authentication to create a read-write session, via an embedded API key, and stores + returns the resulting auth bundle that contains the encrypted API key. This auth bundle (also referred to as a credential bundle) can be injected into an iframeStamper, resulting in a touch-free authenticator. Unlike `loginWithReadWriteSession`, this method assumes the end-user's organization ID (i.e. the sub-organization ID) is already known.
+Uses Passkey authentication to create a read-write session, via an embedded API key, and stores + returns the resulting auth bundle that contains the encrypted API key. This auth bundle (also referred to as a credential bundle) can be injected into an iframeStamper, resulting in a touch-free authenticator. Unlike `loginWithReadWriteSession`, this method assumes the end-user's organization ID (i.e. the sub-organization ID) is already known.
 
 ```typescript
 import { Turnkey } from "@turnkey/sdk-browser";
@@ -552,6 +860,10 @@ if (subOrgIdsResponse.organizationIds?.length > 0) {
  )
 }
 ```
+
+### `getSession()`
+
+Attempts to refresh an existing, active session and will extend the session expiry using the `expirationSeconds` parameter
 
 ### `currentUserSession()`
 

--- a/docs/sdks/javascript-browser.mdx
+++ b/docs/sdks/javascript-browser.mdx
@@ -55,7 +55,7 @@ const turnkey = new Turnkey({
     name: 'config',
     type: {
       name: 'TurnkeySDKBrowserConfig',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L96'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L179'
     }
   }}
   isRequired
@@ -162,7 +162,7 @@ Authenticate a user via the credential bundle emailed to them and creates a read
     name: 'params',
     type: {
       name: 'LoginWithBundleParams',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L219'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L219'
     }
   }}
   isRequired
@@ -226,7 +226,7 @@ Authenticate a user via Passkey and create a read-only or read-write session
     name: 'params',
     type: {
       name: 'LoginWithPasskeyParams',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L224'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L224'
     }
   }}
   isRequired
@@ -305,7 +305,7 @@ Log in with a session object created via a server action. The session can be eit
     name: 'session',
     type: {
       name: 'Session',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L25'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L25'
     }
   }}
   isRequired
@@ -326,7 +326,7 @@ Login with awallet
     name: 'params',
     type: {
       name: 'LoginWithWalletParams',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L231'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L231'
     }
   }}
   isRequired
@@ -404,7 +404,7 @@ Attempts to refresh an existing, active session and will extend the session expi
     name: 'request',
     type: {
       name: 'RefreshSessionParams',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L213'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L213'
     }
   }}
   isRequired
@@ -418,7 +418,7 @@ An object containing the `RefreshSessionParams`.
     name: 'sessionType',
     type: {
       name: 'SessionType',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-browser/src/__types__/base.ts#L20'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-browser/src/__types__/base.ts#L20'
     }
   }}
   isRequired

--- a/docs/sdks/javascript-server.mdx
+++ b/docs/sdks/javascript-server.mdx
@@ -56,7 +56,7 @@ const turnkey = new Turnkey({
     name: 'config',
     type: {
       name: 'TurnkeySDKServerConfig',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L79'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L88'
     }
   }}
   isRequired
@@ -176,10 +176,7 @@ export default turnkeyProxyHandler;
 
 ## TurnkeyServerClient
 
-TODO:
-The `TurnkeyServerClient` wraps Turnkey's basic SDK client with browser session management functionality. This client allows you to create a read only session that only authenticates read requests, or a read write session. It uses local storage for session management. The constructor for `TurnkeyServerClient` optionally takes in `AuthClient` which tracks which client was used for the initial authentication, to be used for retrieval purposes. Each subclass of `TurnkeyServerClient` (including `TurnkeyPasskeyClient`, `TurnkeyIframeClient` and `TurnkeyWalletClient`) will also set this to the respective value when used.
-
-Below are all of the methods exposed by `TurnkeyServerClient`
+The `@turnkey/sdk-server` exposes NextJS Server Actions. These server actions can be used to facilitate implementing common authentication flows.
 
 ### `sendOtp()`
 
@@ -213,7 +210,7 @@ if (initAuthResponse && initAuthResponse.otpId) {
     name: 'request',
     type: {
       name: 'SendOtpRequest',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L172'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L172'
     }
   }}
   isRequired
@@ -329,7 +326,7 @@ if (authSession?.token) {
     name: 'request',
     type: {
       name: 'VerifyOtpRequest',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L157'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L157'
     }
   }}
   isRequired
@@ -363,7 +360,7 @@ The ID of the sub organization for the given request
   isRequired
 >
 
-The ID for the given OTP request. This ID is returned in the [`SendOtpResponse`](https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L182) from [`sendOtp()`](#sendotp)
+The ID for the given OTP request. This ID is returned in the [`SendOtpResponse`](https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L182) from [`sendOtp()`](#sendotp)
 
 </Parameter>
 
@@ -445,7 +442,7 @@ if (oauthSession && oauthSession.token) {
     name: 'request',
     type: {
       name: 'OauthRequest',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L165'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L165'
     }
   }}
   isRequired
@@ -540,7 +537,7 @@ const sendCredentialResponse = await server.sendCredential({
     name: 'request',
     type: {
       name: 'InitEmailAuthRequest',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L186'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L186'
     }
   }}
   isRequired
@@ -655,7 +652,7 @@ Invalidate all pre-existing sessions. Defaults to `false`.
     name: 'emailCustomization',
     type: {
       name: 'EmailCustomization',
-      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L280'
+      link: 'https://github.com/tkhq/sdk/blob/494911d948d0a53c0d00aa01e9821aefd5e3f80d/packages/sdk-server/src/__types__/base.ts#L280'
     }
   }}
 >

--- a/docs/sdks/javascript-server.mdx
+++ b/docs/sdks/javascript-server.mdx
@@ -173,3 +173,509 @@ export default turnkeyProxyHandler;
 
 // this will sign requests made with the client-side `serverSign` function with the root organization's API key for the allowedMethods in the config
 ```
+
+## TurnkeyServerClient
+
+TODO:
+The `TurnkeyServerClient` wraps Turnkey's basic SDK client with browser session management functionality. This client allows you to create a read only session that only authenticates read requests, or a read write session. It uses local storage for session management. The constructor for `TurnkeyServerClient` optionally takes in `AuthClient` which tracks which client was used for the initial authentication, to be used for retrieval purposes. Each subclass of `TurnkeyServerClient` (including `TurnkeyPasskeyClient`, `TurnkeyIframeClient` and `TurnkeyWalletClient`) will also set this to the respective value when used.
+
+Below are all of the methods exposed by `TurnkeyServerClient`
+
+### `sendOtp()`
+
+Initiate an OTP authentication flow for either an `EMAIL` or `SMS`
+
+```typescript
+import { server } from "@turnkey/sdk-server";
+
+const initAuthResponse = await server.sendOtp({
+  suborgID: suborgId!,
+  otpType,
+  contact: value,
+  ...(emailCustomization && { emailCustomization }),
+  ...(sendFromEmailAddress && { sendFromEmailAddress }),
+  ...(customSmsMessage && { customSmsMessage }),
+  userIdentifier: authIframeClient?.iframePublicKey!,
+});
+
+if (initAuthResponse && initAuthResponse.otpId) {
+  // proceed to verifyOtp
+} else {
+  // error handling
+}
+```
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'request',
+    type: {
+      name: 'SendOtpRequest',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L172'
+    }
+  }}
+  isRequired
+>
+
+An object containing the parameters to initiate an `EMAIL` or `SMS` OTP authentication flow.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'suborgID',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The ID of the sub organization for the given request
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'otpType',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The type of OTP request, either `EMAIL` or `SMS`
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'contact',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The contact
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'customSmsMessage',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Use to customize the SMS message
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'userIdentifier',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+IP Address, iframePublicKey, or other unique identifier used for rate limiting
+
+</Parameter>
+
+</Parameter>
+
+### `verifyOtp()`
+
+Verify the OTP Code sent to the user via `EMAIL` or `SMS`. If verification is successful, a Session is returned which is used to log in with.
+
+```typescript
+import { server } from "@turnkey/sdk-server";
+
+const authSession = await server.verifyOtp({
+  suborgID: suborgId,
+  otpId,
+  otpCode: otp,
+  targetPublicKey: authIframeClient!.iframePublicKey!,
+  sessionLengthSeconds,
+});
+
+if (authSession?.token) {
+  // log in with Session
+  await authIframeClient!.loginWithSession(authSession);
+  // call onValidateSuccess callback
+  await onValidateSuccess();
+} else {
+  // error handling
+}
+```
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'request',
+    type: {
+      name: 'VerifyOtpRequest',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L157'
+    }
+  }}
+  isRequired
+>
+
+An object containing the parameters to verify an OTP authentication attempt.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'suborgID',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The ID of the sub organization for the given request
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'otpId',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The ID for the given OTP request. This ID is returned in the [`SendOtpResponse`](https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L182) from [`sendOtp()`](#sendotp)
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'otpCode',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The OTP Code sent to the user
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The public key of the target user.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionLengthSeconds',
+    type: {
+      name: 'number',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+</Parameter>
+
+### `oauth()`
+
+Complete an OAuth authentication flow once the OIDC Token has been obtain from the OAuth provider.
+
+```typescript
+import { server } from "@turnkey/sdk-server";
+
+const oauthSession = await server.oauth({
+  suborgID: suborgId!,
+  oidcToken: credential,
+  targetPublicKey: authIframeClient?.iframePublicKey!,
+  sessionLengthSeconds: authConfig.sessionLengthSeconds,
+});
+
+if (oauthSession && oauthSession.token) {
+  // log in with Session
+  await authIframeClient!.loginWithSession(oauthSession);
+  // call onAuthSuccess callback
+  await onAuthSuccess();
+} else {
+  // error handling
+}
+```
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'request',
+    type: {
+      name: 'OauthRequest',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L165'
+    }
+  }}
+  isRequired
+>
+
+An object containing the parameters to complete an OAuth authentication flow.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'suborgID',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The ID of the sub organization for the given request
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'oidcToken',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The OIDC (OpenID Connect) Token issued by the OAuth provider which contains basic profile information about the user.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The public key of the target user.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionLengthSeconds',
+    type: {
+      name: 'number',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+</Parameter>
+
+### `sendCredential()`
+
+```typescript
+import { server } from "@turnkey/sdk-server";
+
+const sendCredentialResponse = await server.sendCredential({
+  email,
+  targetPublicKey: authIframeClient?.iframePublicKey!,
+  organizationId: suborgId!,
+  ...(apiKeyName && { apiKeyName }),
+  ...(sendFromEmailAddress && { sendFromEmailAddress }),
+  ...(sessionLengthSeconds && { sessionLengthSeconds }),
+  ...(invalidateExisting && { invalidateExisting }),
+  ...(emailCustomization && { emailCustomization }),
+  ...(sendFromEmailAddress && { sendFromEmailAddress }),
+});
+```
+
+#### Parameters
+
+<Parameter
+  style={{ borderBottom: "none", paddingBottom: "none"}}
+  param={{
+    name: 'request',
+    type: {
+      name: 'InitEmailAuthRequest',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L186'
+    }
+  }}
+  isRequired
+>
+
+An object containing the parameters to verify an OTP authentication attempt.
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'suborgID',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The ID of the sub organization for the given request
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'email',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The email address provided by the user
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'targetPublicKey',
+    type: {
+      name: 'string',
+    }
+  }}
+  isRequired
+>
+
+The public key of the target user.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'apiKeyName',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+The name of the API Key
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'userIdentifier',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+IP Address, iframePublicKey, or other unique identifier used for rate limiting
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sessionLengthSeconds',
+    type: {
+      name: 'number',
+    }
+  }}
+>
+
+Specify the length of the session in seconds. Defaults to 900 seconds or 15 minutes.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'invalidateExisting',
+    type: {
+      name: 'boolean',
+    }
+  }}
+>
+
+Invalidate all pre-existing sessions. Defaults to `false`.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'emailCustomization',
+    type: {
+      name: 'EmailCustomization',
+      link: 'https://github.com/tkhq/sdk/blob/main/packages/sdk-server/src/__types__/base.ts#L280'
+    }
+  }}
+>
+
+An optional to customize the email.
+
+</Parameter>
+
+<Parameter
+  style={{ paddingTop: '0', paddingLeft: "12px"}}
+  param={{
+    name: 'sendFromEmailAddress',
+    type: {
+      name: 'string',
+    }
+  }}
+>
+
+Provide a custom email address which will be used as the sender of the email.
+
+</Parameter>
+
+</Parameter>

--- a/docs/solutions/embedded-wallets/code-examples/create-sub-org-passkey.mdx
+++ b/docs/solutions/embedded-wallets/code-examples/create-sub-org-passkey.mdx
@@ -240,7 +240,7 @@ import { Turnkey } from "@turnkey/sdk-server";
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
-  baseUrl: "https://api.turnkey.com",
+  apiBaseUrl: "https://api.turnkey.com",
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
   defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,
@@ -255,7 +255,7 @@ import { Turnkey } from "@turnkey/sdk-server";
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
-  baseUrl: "https://api.turnkey.com",
+  apiBaseUrl: "https://api.turnkey.com",
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
   defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,

--- a/docs/solutions/embedded-wallets/code-examples/email-recovery.mdx
+++ b/docs/solutions/embedded-wallets/code-examples/email-recovery.mdx
@@ -121,7 +121,7 @@ import { Turnkey } from "@turnkey/sdk-server";
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
-  baseUrl: "https://api.turnkey.com",
+  apiBaseUrl: "https://api.turnkey.com",
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
   defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,
@@ -136,7 +136,7 @@ import { Turnkey } from "@turnkey/sdk-server";
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
-  baseUrl: "https://api.turnkey.com",
+  apiBaseUrl: "https://api.turnkey.com",
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
   defaultOrganizationId: process.env.TURNKEY_ORGANIZATION_ID,

--- a/docs/solutions/embedded-wallets/code-examples/wallet-auth.mdx
+++ b/docs/solutions/embedded-wallets/code-examples/wallet-auth.mdx
@@ -127,13 +127,13 @@ For more information on Next.js server actions, see the Next.js documentation on
 import { Turnkey } from "@turnkey/sdk-server";
 import { turnkeyConfig } from "./config";
 
-const { baseUrl, defaultOrganizationId } = turnkeyConfig;
+const { apiBaseUrl, defaultOrganizationId } = turnkeyConfig;
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
-  baseUrl,
+  apiBaseUrl,
   defaultOrganizationId,
 }).apiClient();
 ```
@@ -145,13 +145,13 @@ const turnkeyServer = new Turnkey({
 import { Turnkey } from "@turnkey/sdk-server";
 import { turnkeyConfig } from "./config";
 
-const { baseUrl, defaultOrganizationId } = turnkeyConfig;
+const { apiBaseUrl, defaultOrganizationId } = turnkeyConfig;
 
 // Initialize the Turnkey Server Client on the server-side
 const turnkeyServer = new Turnkey({
   apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY,
   apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY,
-  baseUrl,
+  apiBaseUrl,
   defaultOrganizationId,
 }).apiClient();
 ```
@@ -305,7 +305,7 @@ import { DEFAULT_ETHEREUM_ACCOUNTS } from "@turnkey/sdk-browser";
 
 export const createSubOrg = async (
   publicKey: string,
-  curveType: "API_KEY_CURVE_ED25519" | "API_KEY_CURVE_SECP256K1",
+  curveType: "API_KEY_CURVE_ED25519" | "API_KEY_CURVE_SECP256K1"
 ) => {
   const apiKeys = [
     {
@@ -397,7 +397,7 @@ import { DEFAULT_ETHEREUM_ACCOUNTS } from "@turnkey/sdk-browser";
 
 export const createSubOrg = async (
   publicKey: string,
-  curveType: "API_KEY_CURVE_ED25519" | "API_KEY_CURVE_SECP256K1",
+  curveType: "API_KEY_CURVE_ED25519" | "API_KEY_CURVE_SECP256K1"
 ) => {
   const apiKeys = [
     {
@@ -657,7 +657,7 @@ export default function WalletAuth() {
   const { walletClient, getActiveClient } = useTurnkey();
   // State to hold the read-write client
   const [readWriteClient, setReadWriteClient] = useState<IframeClient | null>(
-    null,
+    null
   );
 
   const login = async () => {
@@ -694,7 +694,7 @@ export default function WalletAuth() {
   const { walletClient, getActiveClient } = useTurnkey();
   // State to hold the read-write client
   const [readWriteClient, setReadWriteClient] = useState<IframeClient | null>(
-    null,
+    null
   );
 
   const login = async () => {
@@ -746,7 +746,7 @@ const getReadWriteClient = async (credentialBundle: string) => {
   const iframeContainerId = "turnkey-auth-iframe-container-id";
 
   const authIframeClient = await turnkey.iframeClient(
-    document.getElementById(iframeContainerId),
+    document.getElementById(iframeContainerId)
   );
 
   const authenticationResponse =
@@ -779,7 +779,7 @@ export const login = async (publicKey: string) => {
     // If the login was successful, initialize the read-write client
     if (readSessionResponse) {
       const readWriteClient = await getReadWriteClient(
-        readSessionResponse.credentialBundle,
+        readSessionResponse.credentialBundle
       );
 
       // We can use the read-write client to create a new wallet


### PR DESCRIPTION
- sdk-server - add documentation for the following server actions
  - `sendOtp()`
  - `verifyOtp()`
  - `oauth()`
  - `sendCredential()`
- sdk-browser - add documentation for the following new SDK methods
  - TurnkeyBrowserClient
    - `loginWithBundle()`
    - `loginWithPasskey()`
    - `loginWithSession()`
    - `loginWithWallet()`
    - `refreshSession()`
  - TurnkeyBrowserSDK
    - `getSession()`