### PR TITLE
chore: update session type in docs

### DIFF
--- a/sdks/javascript-browser.mdx
+++ b/sdks/javascript-browser.mdx
@@ -152,7 +152,7 @@ const iframeClient = await turnkeySDK.iframeClient();
 
 // Authenticate with a passkey to create a read-write session
 const session = await browserClient.loginWithPasskey({
-  sessionType: "READ_WRITE",
+  sessionType: "SESSION_TYPE_READ_WRITE",
   iframeClient: iframeClient,
   expirationSeconds: "900", // 15 minutes
 });
@@ -225,7 +225,7 @@ const iframeClient = await turnkeySDK.iframeClient();
 
 // Login with a wallet to create a read-write session
 const session = await browserClient.loginWithWallet({
-  sessionType: "READ_WRITE",
+  sessionType: "SESSION_TYPE_READ_WRITE",
   iframeClient: iframeClient,
   expirationSeconds: "900", // 15 minutes
 });
@@ -272,7 +272,7 @@ const browserClient = new TurnkeyBrowserClient(config);
 
 // Refresh the current session
 const refreshedSession = await browserClient.refreshSession({
-  sessionType: "READ_WRITE",
+  sessionType: "SESSION_TYPE_READ_WRITE",
   expirationSeconds: "900", // 15 minutes
 });
 ```


### PR DESCRIPTION
Update SDK-Browser docs to use `SESSION_TYPE_READ_WRITE` instead of `READ_WRITE`