### PR TITLE
CSV to table

### DIFF
--- a/authentication/sms.mdx
+++ b/authentication/sms.mdx
@@ -8,7 +8,149 @@ sidebarTitle: "SMS"
 
 SMS authentication is available to all Enterprise customers. To enable this feature, please reach out to the Turnkey team.
 
-SMS pricing is usage-based and varies depending on the country of the destination phone number. A downloadable price list for all supported countries is available <a href="/assets/files/sms-prices.csv" download>here as a CSV</a>.
+SMS pricing is usage-based and varies depending on the country of the destination phone number. See below for a list of prices for all supported countries.
+
+<Accordion title="SMS Pricing List">
+| Country | Cost (cents) |
+|---------|---------------|
+| Albania | 9.029 |
+| Andorra | 11.380 |
+| Angola | 8.983 |
+| Argentina | 6.928 |
+| Armenia | 14.113 |
+| Australia | 3.450 |
+| Austria | 10.526 |
+| Azerbaijan | 36.910 |
+| Bahamas | 7.011 |
+| Bahrain | 3.549 |
+| Bangladesh | 24.928 |
+| Barbados | 13.238 |
+| Belgium | 9.582 |
+| Belize | 26.502 |
+| Benin | 12.250 |
+| Bolivia | 14.057 |
+| Bosnia And Herzegovina | 7.463 |
+| Botswana | 3.831 |
+| Brazil | 2.297 |
+| British Virgin Islands | 18.022 |
+| Brunei | 1.289 |
+| Cameroon | 12.333 |
+| Cape Verde | 13.740 |
+| Cayman Islands | 7.300 |
+| Chad | 14.440 |
+| Chile | 5.178 |
+| Colombia | 0.157 |
+| Costa Rica | 4.678 |
+| Croatia | 8.741 |
+| Curacao | 12.667 |
+| Cyprus | 2.995 |
+| Czechia | 6.609 |
+| Democratic Republic Of The Congo | 11.435 |
+| Denmark | 6.206 |
+| Djibouti | 11.180 |
+| Dominica | 13.002 |
+| Ecuador | 17.655 |
+| El Salvador | 6.609 |
+| Equatorial Guinea | 13.060 |
+| Estonia | 7.687 |
+| Faroe Islands | 4.369 |
+| Fiji | 15.002 |
+| Finland | 10.009 |
+| France | 6.933 |
+| French Polynesia | 12.860 |
+| Gambia | 8.444 |
+| Georgia | 17.028 |
+| Germany | 8.848 |
+| Ghana | 16.611 |
+| Gibraltar | 7.611 |
+| Greece | 8.621 |
+| Grenada | 14.593 |
+| Guadelupe | 16.302 |
+| Guatemala | 10.060 |
+| Guinea | 14.260 |
+| Guyana | 11.133 |
+| Haiti | 16.299 |
+| Honduras | 8.310 |
+| Hong Kong | 7.656 |
+| Hungary | 10.824 |
+| Iceland | 9.640 |
+| India | 6.900 |
+| Indonesia | 36.308 |
+| Ireland | 9.556 |
+| Israel | 17.031 |
+| Italy | 7.500 |
+| Ivory Coast | 19.076 |
+| Jamaica | 16.714 |
+| Japan | 7.451 |
+| Kosovo | 11.404 |
+| Kuwait | 14.940 |
+| Kyrgyzstan | 20.282 |
+| Laos | 5.365 |
+| Latvia | 6.848 |
+| Lebanon | 25.954 |
+| Lesotho | 9.890 |
+| Liberia | 8.793 |
+| Lithuania | 4.358 |
+| Luxembourg | 8.412 |
+| Madagascar | 36.064 |
+| Malaysia | 15.107 |
+| Maldives | 4.149 |
+| Mali | 27.733 |
+| Malta | 6.980 |
+| Mauritius | 15.744 |
+| Mexico | 5.956 |
+| Moldova | 6.226 |
+| Mongolia | 12.765 |
+| Montenegro | 6.569 |
+| Morocco | 17.586 |
+| Mozambique | 12.638 |
+| Namibia | 8.284 |
+| Nepal | 15.017 |
+| Netherlands | 11.890 |
+| New Zealand | 9.416 |
+| Nicaragua | 7.773 |
+| Niger | 26.123 |
+| Nigeria | 22.809 |
+| Norway | 8.675 |
+| Pakistan | 33.692 |
+| Panama | 8.786 |
+| Peru | 9.209 |
+| Philippines | 15.885 |
+| Poland | 3.222 |
+| Portugal | 3.031 |
+| Puerto Rico 1 | 1.356 |
+| Puerto Rico 2 | 1.356 |
+| Qatar | 3.973 |
+| Reunion | 17.186 |
+| Romania | 7.804 |
+| Saint Lucia | 8.100 |
+| Saint Vincent And Grenadines | 13.192 |
+| Samoa | 15.394 |
+| Saudi Arabia | 10.154 |
+| Senegal | 18.815 |
+| Serbia | 5.100 |
+| Seychelles | 4.272 |
+| Sierra Leone | 18.370 |
+| Singapore | 3.918 |
+| Slovenia | 14.522 |
+| South Africa | 1.980 |
+| South Korea | 2.414 |
+| Spain | 6.087 |
+| Suriname | 12.681 |
+| Swaziland | 8.031 |
+| Sweden | 7.256 |
+| Switzerland | 5.124 |
+| Tajikistan | 44.377 |
+| Tanzania | 19.222 |
+| Thailand | 1.272 |
+| Togo | 14.970 |
+| Trinidad And Tobago | 12.953 |
+| Tunisia | 25.684 |
+| United States | 0.581 |
+| Uruguay | 7.317 |
+| Uzbekistan | 36.803 |
+| Venezuela | 6.780 |
+</Accordion>
 
 ## How It Works
 


### PR DESCRIPTION
Since we haven't yet figured out a simple way to make the CSV file downloadable, moving this data (temporarily) to a MD table behind an accordion to unblock public launch of SMS feature.