### PR TITLE
Move proxying signed requests as a standalone page

### DIFF
--- a/authentication/passkeys/integration.mdx
+++ b/authentication/passkeys/integration.mdx
@@ -76,13 +76,3 @@ We're here to make this as easy as possible for you and your team!
 ## Passkey wallets with sub-organizations
 
 If you're wondering how to create independent, non-custodial wallets for your end-users, head to [Sub-Organizations](/concepts/sub-organizations). In short: you'll be able to pass the registered passkeys as part of a "create sub-organization" activity, making your end-users the sole owners of any resource created within the sub-organization (including private keys). Your organization will only have read permissions.
-
-## Proxying signed requests
-
-Turnkey has an open CORS policy for its public API. This means your frontend can choose to POST sign requests straight to `https://api.turnkey.com`. Your frontend can also choose to forward the requests via a backend server (which POSTs the signed request to Turnkey).
-
-How should you decide what to do? Here are some considerations:
-
-* A backend proxy can be useful if you need to inspect and persist activity results. For example: if your users are creating wallets, you might want to persist the addresses. If your users are signing transactions, you might want to broadcast on their behalf.
-* Another reason why a backend server could be beneficial is monitoring, feature toggles, and validation: with a proxy you're able to control which requests are proxied and which aren't. You can also perform additional validation before signed requests are forwarded to Turnkey.
-* POSTing signed requests directly from your app frontend to Turnkey saves you the burden of running a proxy server, and takes you out of the loop so that your end-users interact directly with Turnkey. This is a "hands-off" approach that can work well if you want to give your end-users maximum flexibility and ownership over their sub-organization.

--- a/authentication/proxying-signed-requests.mdx
+++ b/authentication/proxying-signed-requests.mdx
@@ -1,0 +1,10 @@
+---
+title: "Proxying signed requests"
+description: "Turnkey has an open CORS policy for its public API. This means your frontend can choose to POST sign requests straight to `https://api.turnkey.com`. Your frontend can also choose to forward the requests via a backend server (which POSTs the signed request to Turnkey)."
+---
+
+How should you decide what to do? Here are some considerations:
+
+* A backend proxy can be useful if you need to inspect and persist activity results. For example: if your users are creating wallets, you might want to persist the addresses. If your users are signing transactions, you might want to broadcast on their behalf.
+* Another reason why a backend server could be beneficial is monitoring, feature toggles, and validation: with a proxy you're able to control which requests are proxied and which aren't. You can also perform additional validation before signed requests are forwarded to Turnkey.
+* POSTing signed requests directly from your app frontend to Turnkey saves you the burden of running a proxy server, and takes you out of the loop so that your end-users interact directly with Turnkey. This is a "hands-off" approach that can work well if you want to give your end-users maximum flexibility and ownership over their sub-organization.

--- a/docs.json
+++ b/docs.json
@@ -83,7 +83,8 @@
                   "authentication/social-logins",
                   "authentication/sms",
                   "authentication/sessions",
-                  "authentication/backend-setup"
+                  "authentication/backend-setup",
+                  "authentication/proxying-signed-requests"
                 ]
               },
               {


### PR DESCRIPTION
Moving out from the passkey section, should apply to p256 key stamps as well