### PR TITLE
API Reference navigation within the same page

### DIFF
--- a/snippets/api/endpoint-filter.mdx
+++ b/snippets/api/endpoint-filter.mdx
@@ -78,12 +78,11 @@ return (
               data-tags={endpoint.tags.map((t) => t.id).join(",")}
               data-endpoint-type={endpoint.type}
             >
-              <a
-                target="_self"
-                className="py-2 font-normal border-b border-gray-100 dark:border-gray-700 group flex flex-row justify-between items-start md:items-center"
-                href={`${endpoint.type === "query" ? "queries" : "activities"}/${
-                  endpoint.id
-                }`}
+              <span
+                onClick={() => {
+                  window.location.href = `${endpoint.type === "query" ? "queries" : "activities"}/${endpoint.id}`;
+                }}
+                className="cursor-pointer py-2 font-normal border-b border-gray-100 dark:border-gray-700 group flex flex-row justify-between items-start md:items-center"
               >
                 <div className="flex flex-row gap-2 items-start md:items-center font-normal">
                   <div className="">{endpoint.name}</div>
@@ -99,7 +98,7 @@ return (
                     </span>
                   ))}
                 </div>
-              </a>
+              </span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
Previously when navigating the API reference clicking on an endpoint would open a new tab, resulting in poor UX. This PR has the navigation occur within the same page