### PR TITLE
remove link to onramp demo

### DIFF
--- a/snippets/shared/fiat-on-ramp.mdx
+++ b/snippets/shared/fiat-on-ramp.mdx
@@ -33,8 +33,6 @@ Fiat Onramp is available to all Enterprise customers. To enable this feature, pl
 
 ## Demos
 
-To interact with a demo of our Fiat Onramp, visit: https://wallets.turnkey.com/
-
 ### Coinbase
 
 The Coinbase demo is running in a sandbox environment which means:


### PR DESCRIPTION
- remove link to onramp demo at wallets.turnkey.com until we release the new SDK demo
<img width="781" height="483" alt="Screenshot 2025-08-11 at 13 33 22" src="https://github.com/user-attachments/assets/05556cda-7156-421b-8d95-004bd0959a84" />
