### PR TITLE
docs: fix API method names from list* to get*

### DIFF
--- a/api-reference/queries/list-activities.mdx
+++ b/api-reference/queries/list-activities.mdx
@@ -5022,15 +5022,15 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listActivities({
+const response = await turnkeyClient.apiClient().getActivities({
   organizationId: "<string> (Unique identifier for a given organization.)",
-  filterByStatus: "<ACTIVITY_STATUS_CREATED>" // Array of activity statuses filtering which activities will be listed in the response.,
+  filterByStatus: ["<ACTIVITY_STATUS_CREATED>"], // Array of activity statuses filtering which activities will be listed in the response.,
   paginationOptions: { // paginationOptions field,
     limit: "<string> (A limit of the number of object to be returned, between 1 and 100. Defaults to 10.)",
     before: "<string> (A pagination cursor. This is an object ID that enables you to fetch all objects before this ID.)",
     after: "<string> (A pagination cursor. This is an object ID that enables you to fetch all objects after this ID.)",
   },
-  filterByType: "<ACTIVITY_TYPE_CREATE_API_KEYS>" // Array of activity types filtering which activities will be listed in the response.
+  filterByType: ["<ACTIVITY_TYPE_CREATE_API_KEYS>"] // Array of activity types filtering which activities will be listed in the response.
 });
 ```
 

--- a/api-reference/queries/list-policies.mdx
+++ b/api-reference/queries/list-policies.mdx
@@ -98,7 +98,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listPolicies({
+const response = await turnkeyClient.apiClient().getPolicies({
   organizationId: "<string> (Unique identifier for a given organization.)"
 });
 ```

--- a/api-reference/queries/list-private-keys.mdx
+++ b/api-reference/queries/list-private-keys.mdx
@@ -122,7 +122,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listPrivateKeys({
+const response = await turnkeyClient.apiClient().getPrivateKeys({
   organizationId: "<string> (Unique identifier for a given organization.)"
 });
 ```

--- a/api-reference/queries/list-smart-contract-interfaces.mdx
+++ b/api-reference/queries/list-smart-contract-interfaces.mdx
@@ -98,7 +98,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listSmartContractInterfaces({
+const response = await turnkeyClient.apiClient().getSmartContractInterfaces({
   organizationId: "<string> (Unique identifier for a given organization.)"
 });
 ```

--- a/api-reference/queries/list-users.mdx
+++ b/api-reference/queries/list-users.mdx
@@ -272,7 +272,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listUsers({
+const response = await turnkeyClient.apiClient().getUsers({
   organizationId: "<string> (Unique identifier for a given organization.)"
 });
 ```

--- a/api-reference/queries/list-wallets-accounts.mdx
+++ b/api-reference/queries/list-wallets-accounts.mdx
@@ -140,7 +140,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listWalletAccounts({
+const response = await turnkeyClient.apiClient().getWalletAccounts({
   organizationId: "<string> (Unique identifier for a given organization.)",
   walletId: "<string> (Unique identifier for a given wallet. If not provided, all accounts for the organization will be returned.)",
   paginationOptions: { // paginationOptions field,

--- a/api-reference/queries/list-wallets.mdx
+++ b/api-reference/queries/list-wallets.mdx
@@ -89,7 +89,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().listWallets({
+const response = await turnkeyClient.apiClient().getWallets({
   organizationId: "<string> (Unique identifier for a given organization.)"
 });
 ```

--- a/api-reference/queries/who-am-i.mdx
+++ b/api-reference/queries/who-am-i.mdx
@@ -51,7 +51,7 @@ const turnkeyClient = new Turnkey({
   defaultOrganizationId: process.env.ORGANIZATION_ID!,
 });
 
-const response = await turnkeyClient.apiClient().whoami({
+const response = await turnkeyClient.apiClient().getWhoami({
   organizationId: "<string> (Unique identifier for a given organization. If the request is being made by a WebAuthN user and their sub-organization ID is unknown, this can be the parent organization ID; using the sub-organization ID when possible is preferred due to performance reasons.)"
 });
 ```


### PR DESCRIPTION
Update API method names in the docs to match the actual method name.

Affected methods:
`listActivities`, `listPolicies`, `listPrivateKeys`, `listSmartContractInterfaces`, `listUsers`, `listWallets`, `listWalletAccounts`, `whoami`

Reason:
The old names caused runtime errors like: `TypeError: turnkeyClient.apiClient(...).listActivities is not a function`

