### PR TITLE
fix link to onramp providers and add account creation referral links

### DIFF
--- a/snippets/shared/fiat-on-ramp.mdx
+++ b/snippets/shared/fiat-on-ramp.mdx
@@ -19,7 +19,7 @@ Fiat Onramp is available to all Enterprise customers. To enable this feature, pl
 
 ## Prerequisites
 
-1. Choose the Onramp provider(s) you want to integrate with. See our current list of supported [Onramp Providers](#on-ramp-providers) below for coverage and pricing to best fit your needs.
+1. Choose the Onramp provider(s) you want to integrate with. See our current list of supported [Onramp Providers](#onramp-providers) below for coverage and pricing to best fit your needs.
 1. Create an account with your chosen Onramp provider(s) and complete the required KYB process.
    - The typical KYB approval timeline will vary by Onramp provider. You can expect review to take 1-4 business days (or longer) depending on document availability and follow-up questions from the Onramp provider’s compliance team.
    - The requirements of the KYB process and the speed of review will vary by Onramp provider. Specific questions should be addressed to the Onramp provider directly.
@@ -33,10 +33,21 @@ Fiat Onramp is available to all Enterprise customers. To enable this feature, pl
 
 ### Onramp Providers
 
-| Provider |                                                                                                            |                                                                                                                |                                                                                                     |                                                                                                                        |
-| :------- | :--------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Coinbase | [Payment Methods](https://docs.cdp.coinbase.com/onramp-&-offramp/developer-guidance/payment-methods)       | [Supported Currencies](https://onramp-asset-availability.vercel.app/)                                          | [Country Support](https://onramp-asset-availability.vercel.app/)                                    | [Fees](https://docs.cdp.coinbase.com/onramp-&-offramp/developer-guidance/faq#what-fees-do-you-charge%3F)               |
-| MoonPay  | [Payment Methods](https://support.moonpay.com/customers/docs/all-supported-payment-methods?lng=en#on-ramp) | [Supported Currencies](https://support.moonpay.com/customers/docs/moonpays-supported-currencies?lng=en#buying) | [Country Support](https://support.moonpay.com/customers/docs/moonpays-unsupported-countries?lng=en) | [Fees](https://support.moonpay.com/customers/docs/all-supported-payment-methods?lng=en#what-are-the-fees-with-moonpay) |
+**Coinbase**
+
+- [Create Account](https://portal.cdp.coinbase.com/)
+- [Payment Methods](https://docs.cdp.coinbase.com/onramp-&-offramp/developer-guidance/payment-methods)
+- [Supported Currencies](https://onramp-asset-availability.vercel.app/)
+- [Country Support](https://onramp-asset-availability.vercel.app/)
+- [Fees](https://docs.cdp.coinbase.com/onramp-&-offramp/developer-guidance/faq#what-fees-do-you-charge%3F)
+
+**MoonPay**
+
+- [Create Account](https://dashboard.moonpay.com/signup?referral=turnkey-FAEuJg)
+- [Payment Methods](https://support.moonpay.com/customers/docs/all-supported-payment-methods?lng=en#on-ramp)
+- [Supported Currencies](https://support.moonpay.com/customers/docs/moonpays-supported-currencies?lng=en#buying)
+- [Country Support](https://support.moonpay.com/customers/docs/moonpays-unsupported-countries?lng=en)
+- [Fees](https://support.moonpay.com/customers/docs/all-supported-payment-methods?lng=en#what-are-the-fees-with-moonpay)
 
 ## Demos
 


### PR DESCRIPTION
### Changes
- fixed broken link to onramp providers from prerequisites section
- added links to create an account / signup on Coinbase / MoonPay
  - MoonPay uses our custom referral link

[Docs Preview Deployment](https://turnkey-0e7c1f5b-bc-update-onramp-onboarding-docs.mintlify.app/products/embedded-wallets/features/fiat-on-ramp#onramp-providers)

### Before
<img width="646" height="171" alt="Screenshot 2025-09-30 at 17 03 43" src="https://github.com/user-attachments/assets/e67307fc-477c-45a1-9f01-359ce20e2aa6" />

### After
<img width="451" height="534" alt="Screenshot 2025-10-01 at 16 39 12" src="https://github.com/user-attachments/assets/a0c4dc21-2675-4929-9320-f6d2cd31b765" />

