### PR TITLE
Update policy language doc

### DIFF
--- a/concepts/policies/language.mdx
+++ b/concepts/policies/language.mdx
@@ -47,8 +47,9 @@ Keywords are reserved words that are dynamically interchanged for real values at
 | **solana.tx**                  | SolanaTransaction    | The parsed Solana transaction payload (see Appendix below)   |
 | **tron.tx**                    | TronTransaction      | The parsed Tron transaction payload (see Appendix below)     |
 | **bitcoin.tx**                 | BitcoinTransaction   | The parsed Bitcoin transaction payload (see Appendix below)  |
-| **wallet**                     | Wallet               | The target wallet used in sign requests                      |
-| **private_key**                | PrivateKey           | The target private key used in sign requests                 |
+| **wallet**                     | Wallet               | The target wallet used in sign + export requests             |
+| **private_key**                | PrivateKey           | The target private key used in sign + export requests        |
+| **wallet_account**             | WalletAccount        | The target wallet account used in sign + export requests     |
 
 ## Types
 


### PR DESCRIPTION
update policy language documentation for private keys, wallet accounts, and wallets, with a new addition for support for export activities in the policy engine