### PR TITLE
Correct API reference link for creating API keys

### DIFF
--- a/concepts/policies/overview.mdx
+++ b/concepts/policies/overview.mdx
@@ -8,4 +8,4 @@ import PolicyEngine from "/snippets/shared/policy-engine.mdx";
 
 <PolicyEngine />
 
-To learn more about our Policies, checkout our Policy Language [here](/concepts/policies/language).
+To learn more about our Policies, check out our Policy Language [here](/concepts/policies/language).

--- a/concepts/users/credentials.mdx
+++ b/concepts/users/credentials.mdx
@@ -21,4 +21,4 @@ Turnkey API requests are authenticated with API key signatures. When you generat
 
 Requests made via SDK or CLI use the private API key to sign requests. Turnkey's public API expects all requests (e.g. to get data or to submit activities) to be signed.
 
-See our [API reference](/api-reference/api-keys/create-api-keys) for how to programmatically create API keys.
+See our [API reference](/api-reference/activities/create-api-keys) for how to programmatically create API keys.

--- a/getting-started/launch-checklist.mdx
+++ b/getting-started/launch-checklist.mdx
@@ -22,7 +22,7 @@ Double check our [resource limits](/concepts/resource-limits) and [rate limits](
 
 ## Logging
 
-- Key identifiers in our service include sub-organization IDs, wallet IDs and addresses. Ensure these identifiers are securely stored, associated with your users as necessary.
+- Key identifiers in our service include sub-organization IDs, wallet IDs and addresses. Ensure these identifiers are securely stored and associated with your users as necessary.
 - Set up logging for activities and include relevant identifiers needed for audit, compliance, or troubleshooting purposes. We recommend logging activity IDs, status, creation date, as well as credential IDs and public keys of the approvers. You should also log other resource IDs if relevant for your data model (policies, tags, wallets, accounts, etc)
 
 ## Errors and retries

--- a/production-checklist/backup-recovery.mdx
+++ b/production-checklist/backup-recovery.mdx
@@ -9,7 +9,7 @@ The below options all involve some combination of authentication methods and pol
 
 ## Root user recovery
 
-Touched on in the [production checklist](/production-checklist/production-checklist#security), the 'native' method of organization recovery in Turnkey is to configure multiple root users (recommended at least 3), who each have hardware authenticators such as biometric auth (TouchID on a MacBook) or a YubiKey physical passkey. With at least 3 root users, it is possible to set up a 2 of 3 [root quorum](/concepts/users/root-quorum) which can bypass the policy engine and assert maximum authority in the case of disaster recovery - even when one root user may have lost their authenticator.
+Touched on in the [production checklist](/production-checklist/production-checklist#security), the **native** method of organization recovery in Turnkey is to configure multiple root users (recommended at least 3), who each have hardware authenticators such as biometric auth (TouchID on a MacBook) or a YubiKey physical passkey. With at least 3 root users, it is possible to set up a 2 of 3 [root quorum](/concepts/users/root-quorum) which can bypass the policy engine and assert maximum authority in the case of disaster recovery - even when one root user may have lost their authenticator.
 
 ### Sub-organizations
 

--- a/production-checklist/production-checklist.mdx
+++ b/production-checklist/production-checklist.mdx
@@ -24,7 +24,7 @@ description: "This checklist contains recommendations and steps specifically for
 
 ## Logging
 
-- Key identifiers in our service include sub-organization IDs, wallet IDs and addresses. Ensure these identifiers are securely stored, associated with your users as necessary.
+- Key identifiers in our service include sub-organization IDs, wallet IDs and addresses. Ensure these identifiers are securely stored and associated with your users as necessary.
 - Set up logging for activities and include relevant identifiers needed for audit, compliance, or troubleshooting purposes. We recommend logging activity IDs, status, creation date, as well as credential IDs and public keys of the approvers. You should also log other resource IDs if relevant for your data model (policies, tags, wallets, accounts, etc)
 
 ## Errors and retries


### PR DESCRIPTION
Prev link was dead

Other misc nits I've found as I onboard and read the docs