### PR TITLE
fix: add EVM and SVM broadcast activities to the overview page

### DIFF
--- a/snippets/data/endpoint-tags.mdx
+++ b/snippets/data/endpoint-tags.mdx
@@ -11,6 +11,28 @@ export const endpoints = [
     ]
   },
   {
+    "name": "Broadcast EVM transaction.",
+    "id": "broadcast-evm-transaction",
+    "type": "activity",
+    "tags": [
+      {
+        "id": "broadcasting",
+        "label": "Broadcasting"
+      }
+    ]
+  },
+  {
+    "name": "Broadcast SVM transaction",
+    "id": "broadcast-svm-transaction",
+    "type": "activity",
+    "tags": [
+      {
+        "id": "broadcasting",
+        "label": "Broadcasting"
+      }
+    ]
+  },
+  {
     "name": "Create a Fiat On Ramp Credential",
     "id": "create-a-fiat-on-ramp-credential",
     "type": "activity",

--- a/snippets/data/endpoint-tags.mdx
+++ b/snippets/data/endpoint-tags.mdx
@@ -11,7 +11,7 @@ export const endpoints = [
     ]
   },
   {
-    "name": "Broadcast EVM transaction.",
+    "name": "Broadcast EVM transaction",
     "id": "broadcast-evm-transaction",
     "type": "activity",
     "tags": [


### PR DESCRIPTION
While reviewing the API reference, I noticed that Broadcast EVM transaction and Broadcast  SVM transaction activities were listed in the left-hand index under Activities but were missing from the overview page. This PR adds both entries to the overview so the page is consistent with the index. 

Before:
<img width="1221" height="465" alt="Screenshot 2026-04-23 at 2 24 58 PM" src="https://github.com/user-attachments/assets/f530f20e-5844-4cc0-bacc-078097643380" />

After:
<img width="1425" height="535" alt="Screenshot 2026-04-23 at 2 27 27 PM" src="https://github.com/user-attachments/assets/5d185601-5956-40cc-927d-a52c91e5d497" />
