### PR TITLE
Add Verifiable Cloud docs section

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -250,6 +250,14 @@
                     ]
                   }
                 ]
+              },
+              {
+                "group": "Verifiable Cloud",
+                "tag": "Beta",
+                "pages": [
+                  "products/verifiable-cloud/overview",
+                  "products/verifiable-cloud/onboarding"
+                ]
               }
             ]
           },

--- a/products/verifiable-cloud/onboarding.mdx
+++ b/products/verifiable-cloud/onboarding.mdx
@@ -14,7 +14,7 @@ This template uses Rust but the concepts carry over to other languages: the appl
 
 Turnkey writes all enclave applications in Rust, but TVC isn't opinionated about languages: as long as your toolchain can statically compile to a binary (ELF), QuorumOS can run it.
 
-If you are planning to use dynamic linking or interpreted languages, get in touch ahead of time and we can look at your toolchain's compatibility.
+If you are planning to use dynamic linking or interpreted languages, [get in touch](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist) ahead of time and we can look at your toolchain's compatibility.
 
 ## Recommended First Steps
 

--- a/products/verifiable-cloud/onboarding.mdx
+++ b/products/verifiable-cloud/onboarding.mdx
@@ -45,4 +45,4 @@ What to ask for:
 
 ## Getting access to TVC
 
-TVC is currently in Beta. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).
+TVC is currently in private Beta. A select group of design partners are already building on it and getting exclusive access to the latest features and capabilities. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).

--- a/products/verifiable-cloud/onboarding.mdx
+++ b/products/verifiable-cloud/onboarding.mdx
@@ -1,0 +1,44 @@
+---
+title: "Building Your First App"
+---
+
+## TVC template
+
+To help with bootstrapping we have put together a template repository, available at [`tkhq/tvc-template`](https://github.com/tkhq/tvc-template).
+
+This repository uses [StageX](https://stagex.tools/) as a build system, has CI workflow to build and test the application, and is a great base to build your own app.
+
+This template uses Rust but the concepts carry over to other languages: the application is a simple webserver listening on configurable port and host.
+
+## Supported languages
+
+Turnkey writes all enclave applications in Rust, which means we have great support and expertise if you are also building in Rust. TVC isn't opinionated about languages however: as long as your toolchain can statically compile to a binary (ELF), QuorumOS can run it.
+
+If you are planning to use dynamic linking or interpreted languages, get in touch ahead of time and we can look at your toolchain's compatibility.
+
+## Recommended First Steps
+
+Start with our minimal template and deploy it within your TVC-enabled organization. To do this, follow our [TVC quickstart guide](/getting-started/verifiable-cloud-quickstart).
+
+Verify it comes up healthy, and confirm one or more endpoints respond correctly. Once the baseline is confirmed, layer your application logic incrementally.
+
+## Known platform limitations
+
+| Limitation  | Workaround   |
+| :-----------| :----------- |
+| Deployment deletion not implemented       | Ask our team on Slack, or simply kick-off another deploy. There can only be one live deployment at a time. Kicking off a new deployment automatically deletes any existing one |
+| No metrics or logs in dashboard         | Ask our team on Slack |
+| No egress connectivity  | Pass signed data as input to your API instead of fetching it from within the TEE |
+| No custom provisioning | Use static provisioning for now. This feature is coming sometime in May.
+
+## Getting help
+
+Slack is the primary channel for async questions, debugging, and quick turnaround on deployment issues. Don't hesitate to use it – especially early on.
+
+What to ask for:
+* Code snippet for reading the quorum key and signing within the TEE
+* Help interpreting deployment config fields
+* Assistance debugging a deployment that isn't coming up as expected
+* Observability you'd want surfaced in the dashboard
+
+**Feedback welcome**: You are among the first developers building a brand-new app on this platform, end-to-end. Your experience with gaps, sharp edges, and missing features is genuinely valuable – please share it!

--- a/products/verifiable-cloud/onboarding.mdx
+++ b/products/verifiable-cloud/onboarding.mdx
@@ -12,7 +12,7 @@ This template uses Rust but the concepts carry over to other languages: the appl
 
 ## Supported languages
 
-Turnkey writes all enclave applications in Rust, which means we have great support and expertise if you are also building in Rust. TVC isn't opinionated about languages however: as long as your toolchain can statically compile to a binary (ELF), QuorumOS can run it.
+Turnkey writes all enclave applications in Rust, but TVC isn't opinionated about languages: as long as your toolchain can statically compile to a binary (ELF), QuorumOS can run it.
 
 If you are planning to use dynamic linking or interpreted languages, get in touch ahead of time and we can look at your toolchain's compatibility.
 
@@ -42,3 +42,7 @@ What to ask for:
 * Observability you'd want surfaced in the dashboard
 
 **Feedback welcome**: You are among the first developers building a brand-new app on this platform, end-to-end. Your experience with gaps, sharp edges, and missing features is genuinely valuable – please share it!
+
+## Getting access to TVC
+
+TVC is currently in Beta. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -6,15 +6,15 @@ title: "Overview"
 
 Turnkey Verifiable Cloud is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system.
 
-Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads.
+Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads, and we plan to support other major cloud providers in the future.
 
 To establish the foundations for our key management system, we had to dig deep into build systems, deployment tooling, verification tooling, provisioning, performance, and scaling.
 This work, developed over 3+ years, is broadly applicable. Any team building at scale within Trusted Execution Environments will encounter the same challenges.
 
-TVC solves these problems transparently for the industry at large, within and outside of crypto. A few of the hard problems solved by TVC:
+TVC solves these problems transparently for the industry at large, within and outside of web3. A few of the hard problems solved by TVC:
 * **Reproducible builds**: These are crucial to leverage remote attestations (see [this blog post](https://quorum.tkhq.xyz/posts/remote-attestations-useless-without-reproducible-builds/)). To support this, we bootstrapped [StageX](https://stagex.tools), an open-source distro focused on reproducibility. TVC works with StageX so reproducibility is handled for you. Learn more about it [here](https://quorum.tkhq.xyz/posts/reproducible-builds-made-easy-introducing-stagex/).
-* **EIF Files**: Packaging applications into EIF files is [easy on the surface](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html) but leaves application developers with load-bearing security decisions: which base OS do I use? How do I handle application upgrades? How do I persist state? Turnkey built [QuorumOS](https://github.com/tkhq/qos) to solve these problems in the context of our own key management platform. TVC is integrated with QOS to handle these problems for you. In TVC, you provide the binary application you'd like to run, and we take care of the rest.
-* **Running enclaves in Kubernetes**: Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling to ensure your application can transparently scale up and down with traffic. We have automated provisioning and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down are automatically replaced and provisioned from already-running enclaves, Operators do not have to wake up in the middle of the night.
+* **Packaging**: Packaging applications into EIF files is [easy on the surface](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html) but leaves application developers with load-bearing security decisions: which base OS do I use? How do I handle application upgrades? How do I persist state? Turnkey built [QuorumOS](https://github.com/tkhq/qos) to solve these problems in the context of our own key management platform. TVC is integrated with QOS to handle these problems for you. In TVC, you provide the binary application you'd like to run, and we take care of the rest.
+* **Running at production scale**: Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling to ensure your application can transparently scale up and down with traffic. We have automated provisioning and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down are automatically replaced and provisioned from already-running enclaves, Operators do not have to wake up in the middle of the night.
 * **Verification tooling**: Turnkey is regularly audited by top security firms to guarantee verification procedures and the code implementing them remains secure and correct over time.
 
 TVC applications get this (and more!) by default because they run on the same infrastructure as Turnkey's own secure workloads.
@@ -37,6 +37,8 @@ Many different types of workloads can benefit from verifiability. Below is a lis
 | VPN nodes                 | Guarantees privacy by proving that forwarded traffic isn't logged anywhere. |
 | Exchanges                 | Ensure no malicious behavior (frontrunning), and create verifiable order books. |
 | PII processing            | Prove that processing does not leak or misuse PII (Personally Identifiable Information). |
+
+These are just a subset of possible use cases. Any computation where two parties need to agree on what was executed can benefit from or require verifiability.
 
 ## Architecture
 
@@ -96,7 +98,7 @@ TVC pricing has two components:
 * A fixed per-month platform fee.
 * Variable pricing based on wall-clock enclave uptime
 
-Get in touch with us for more details.
+[Get in touch with us](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist) for more details.
 
 ## Getting access to TVC
 

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -4,7 +4,7 @@ title: "Overview"
 
 ## What is Turnkey Verifiable Cloud (“TVC”)?
 
-Turnkey Verifiable Cloud is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system.
+Turnkey Verifiable Cloud is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system. With TVC, you can run any code in isolated, verifiable secure enclaves powered by Turnkey’s trusted infrastructure.
 
 Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads, and we plan to support other major cloud providers in the future.
 
@@ -19,7 +19,7 @@ TVC solves these problems transparently for the industry at large, within and ou
 
 TVC is the first TEE platform to offer autoscaling and strong security defaults. Your secure workloads run at scale, on the same infrastructure as Turnkey's own secure workloads.
 
-## Use-cases
+## Use cases
 
 Many different types of workloads can benefit from verifiability. Below is a list of use cases supported by TVC.
 

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -8,7 +8,7 @@ Turnkey Verifiable Cloud is a new offering to externalize the [Foundations](http
 
 Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads, and we plan to support other major cloud providers in the future.
 
-To establish the foundations for our key management system, we had to dig deep into build systems, deployment tooling, verification tooling, provisioning, performance, and scaling.
+To establish the foundations for our key management system, we went deep on build systems, deployment tooling, verification tooling, provisioning, performance, and scaling.
 This work, developed over 3+ years, is broadly applicable. Any team building at scale within Trusted Execution Environments will encounter the same challenges.
 
 TVC solves these problems transparently for the industry at large, within and outside of web3. A few of the hard problems solved by TVC:
@@ -17,7 +17,7 @@ TVC solves these problems transparently for the industry at large, within and ou
 * **Running at production scale**: Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling to ensure your application can transparently scale up and down with traffic. We have automated provisioning and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down are automatically replaced and provisioned from already-running enclaves, Operators do not have to wake up in the middle of the night.
 * **Verification tooling**: Turnkey is regularly audited by top security firms to guarantee verification procedures and the code implementing them remains secure and correct over time.
 
-TVC applications get this (and more!) by default because they run on the same infrastructure as Turnkey's own secure workloads.
+TVC is the first TEE platform to offer autoscaling and strong security defaults. Your secure workloads run at scale, on the same infrastructure as Turnkey's own secure workloads.
 
 ## Use-cases
 
@@ -79,12 +79,18 @@ Each TVC deployment is ultimately specified with a QOS manifest. The information
 
 This manifest document is the source of truth used by QOS to boot your application. It is also the document which must be cryptographically signed for each deployment. QOS Manifests are returned along with the AWS attestation document, within [Boot Proofs](https://whitepaper.turnkey.com/foundations#boot-proofs-and-app-proofs). More on this in the next section.
 
+## Operators
+
+Operators are humans or systems. In TVC, an operator is represented by an alias and a public key. Operator keys can be created and managed externally via our TVC CLI, or managed via Turnkey's own key management APIs.
+
+QuorumOS uses operators to cryptographically control deployments: operators must approve QOS manifests and take part in deployments where Quorum Keys must be injected.
+
 ## Keys, Signatures, and Verification
 
 Your TVC app has access to two keys when it boots:
 
-* Ephemeral Key: a key which is created at boot. This key **never leaves the enclave** and is different for every enclave. A signature by this key is a signature bound to a particular enclave, hence bound to a particular **code version** of your TVC application.
-* Quorum Key: a key which is injected at boot and is the same across all enclaves. This key can be used to encrypt state which needs to survive application upgrades. Internally at Turnkey we use this key to sign or encrypt long-lived data.
+* **Ephemeral Key**: a key which is created at boot. This key **never leaves the enclave** and is different for every enclave. A signature by this key is a signature bound to a particular enclave, hence bound to a particular **code version** of your TVC application.
+* **Quorum Key**: a key which is injected at boot and is the same across all enclaves. This key can be used to encrypt state which needs to survive application upgrades. Internally at Turnkey we use this key to sign or encrypt long-lived data.
 
 Both of these keys follow the [QOS Key Set](https://github.com/tkhq/qos/blob/main/src/qos_p256/SPEC.md) specification. Ephemeral Keys and Quorum Keys can be used to sign data, or to encrypt/decrypt data.
 

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -1,0 +1,102 @@
+---
+title: "Overview"
+---
+
+## What is TVC?
+
+Turnkey Verifiable Cloud ("TVC") is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system.
+
+Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads.
+
+To build the foundations for our key management system we had to dig deep into build systems, deployment tooling, verification tooling, provisioning, performance, and scaling. This work, performed over the course of 3+ years, is valuable and highly general: anyone building within TEEs at scale will encounter similar issues.
+
+TVC is our attempt at solving these problems transparently for the industry at large, within and outside of crypto. A few of the hard problems solved by TVC:
+* Reproducible builds are crucial to leverage remote attestations (see [this blog post](https://quorum.tkhq.xyz/posts/remote-attestations-useless-without-reproducible-builds/)). We have bootstrapped [StageX](https://stagex.tools), an open-source distro focused on reproducibility. Learn more about it [here](https://quorum.tkhq.xyz/posts/reproducible-builds-made-easy-introducing-stagex/). TVC works with StageX so that you do not have to think about reproducibility. It just works.
+* Packaging applications into EIF files is [easy on the surface](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html) but leaves application developers with load-bearing security decisions: which base OS do I use? How do I handle application upgrades? How do I persist state? Turnkey built [QuorumOS](https://github.com/tkhq/qos) to solve these problems in the context of our own key management platform. TVC is integrated with QOS to handle these problems for you. In TVC you provide the binary application you'd like to run, and we take care of the rest.
+* Running enclaves in Kubernetes is hard. Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling so ensure your application can transparently scale up and down with traffic. We have automated provisioning at boot and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down do not wake up operators in the middle of the night. An enclave going down is automatically replaced and provisioned from already-running enclaves.
+* Verification tooling and workflows are sensitive and hard to get right. Turnkey is regularly audited by top security firms to guarantee verification procedures and the code implementing them remains secure and correct over time.
+
+TVC applications get this (and more!) by default because they run on the same infrastructure as Turnkey's own secure workloads.
+
+## Use-cases
+
+Many different types of workloads can benefit from verifiability. Below is a list of use-cases we've discussed internally or externally already.
+
+| Workload type             | Advantages to verifiability                                                                         |
+| :-------------------------| :-------------------------------------------------------------------------------------------------- |
+| Chain Abstraction         | Trustworthy cosigners for cross-chain resource locks (e.g. [OneBalance](https://www.onebalance.io)) |
+| Transaction Construction  | Users know that the unsigned transaction bytes are legitimate. |
+| Transaction Parsing       | Provide accurate metadata about the effects of a transaction. This is critical for trusted wallet UX. See [VisualSign Parser](https://github.com/anchorageoss/visualsign-parser/).  |
+| Oracles                   | Leverage external data without the overhead of full decentralization, on-chain or off-chain. Replace economic incentives with verifiability. |
+| Blockchain nodes          | Allow for private balance lookups, verifiable mempool inclusion, and more. |
+| Sequencers                | Prove correct behavior and eliminate the need for challenge periods and economic incentives around them (e.g. [Base sequencer](https://github.com/base/base/tree/main/crates/proof/tee)) |
+| Identity verification     | Prove no identity is leaked as part of the verification process. |
+| VPN nodes                 | Guarantees privacy by proving that forwarded traffic isn't logged anywhere. |
+| Exchanges                 | Ensure no malicious behavior (frontrunning), and create verifiable order books. |
+| PII processing            | Prove that processing does not leak or misuse PII (Personally Identifiable Information). |
+
+## Architecture
+
+We’ve engineered TVC to fit within the existing Turnkey products and APIs. You will interact with TVC via our [dashboard](https://app.turnkey.com/), via the [TVC CLI](https://github.com/tkhq/rust-sdk/tree/main/tvc), or programmatically via [APIs](/api-reference/overview).
+
+## Applications
+
+TVC is programmable infrastructure, enabling you to create and manage verifiable apps. Each TVC App is deployed on Turnkey infrastructure in the exact same was as Turnkey's own [core enclave apps](https://github.com/tkhq/core-enclaves).
+* TVC Applications are deployed within a Kubernetes cluster operated by Turnkey, using [QuorumOS](https://github.com/tkhq/qos) ("QOS") as a base OS.
+* Key provisioning, high-availability deployments (minimum of 3 replicas), and in-depth verification workflows are supported by default.
+* Because TVC relies on Turnkey for its own operations, it's possible to use Consensus in the context of TVC activities (with [Turnkey Policies](/concepts/policies) or [Root Quorum](/concepts/users/root-quorum))
+
+A TVC Application has a stable [Quorum Key](https://github.com/tkhq/qos#quorum-key) and set of approvers.
+
+## Deployments
+
+Each TVC application can be deployed many times. For every TVC deployment, you will specify:
+
+* an OCI image URL (e.g. `ghcr.io/myorg/myrepo:tag@sha256:…`). This container is pulled by our Kubernetes infrastructure. If the container is private, TVC supports uploading encrypted [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+* an executable path + args: within the container, you must indicate where the desired binary lives such that Turnkey’s infrastructure can extract this binary from its OCI container, and run it within a TEE on your behalf.
+* the port on which external requests should be forwarded. This is typically port 3000. For convenience TVC lets you specify different ports for user requests and health requests made by Turnkey infrastructure.
+* your expected executable digest: this is a security measure, to ensure the binary pulled by Turnkey's infrastructure is the binary you expect.
+
+Once the deployment is submitted and approved, our infrastructure deploys and makes it available on a dedicated subdomain.
+
+| Resource    | Allocation   |
+| :-----------| :----------- |
+| vCPUs       | 2 |
+| RAM         | 1 GiB |
+| Filesystem  | RAM-based (no persistence) |
+| Replicas    | 3 |
+| Ingress     | Load-balanced across all replicas |
+| Sub-domain  | Automated (`<UUID>.turnkey.cloud`) |
+
+## Manifests
+
+Each TVC deployment is ultimately specified with a QOS manifest. The information you provide to TVC APIs (expected digest, executable arguments, and so on) is used to create a new QOS Manifest document. See [`Manifest`](https://github.com/tkhq/qos/blob/d69bcd348073ed7322c0d0423a35b7ab56831de8/src/qos_core/src/protocol/services/boot.rs#L414) for a full definition of the fields within it.
+
+This manifest document is the source of truth used by QOS to boot your application. It is also the document which must be cryptographically signed for each deployment. QOS Manifests are returned along with the AWS attestation document, within [Boot Proofs](https://whitepaper.turnkey.com/foundations#boot-proofs-and-app-proofs). More on this in the next section.
+
+## Keys, Signatures, and Verification
+
+Your TVC app has access to two keys when it boots:
+
+* Ephemeral Key: a key which is created at boot. This key **never leaves the enclave** and is different for every enclave. A signature by this key is a signature bound to a particular enclave, hence bound to a particular **code version** of your TVC application.
+* Quorum Key: a key which is injected at boot and is the same across all enclaves. This key can be used to encrypt state which needs to survive application upgrades. Internally at Turnkey we use this key to sign or encrypt long-lived data.
+
+Both of these keys follow the [QOS Key Set](https://github.com/tkhq/qos/blob/main/src/qos_p256/SPEC.md) specification. Ephemeral Keys and Quorum Keys can be used to sign data, or to encrypt/decrypt data.
+
+App Proofs are signed statements by enclave Ephemeral Keys; Boot Proofs are bundles composed of an AWS attestation document and a QOS manifest.
+
+Together, App Proofs and Boot Proofs can be used to verify workloads end-to-end. See [our documentation](https://docs.turnkey.com/security/turnkey-verified#turnkey-verified) for more on this subject. We’ve already released tooling for proof verification in [Rust](https://crates.io/crates/turnkey_proofs), [JS](https://github.com/tkhq/sdk/blob/main/packages/crypto/src/proof.ts), and [Golang](https://github.com/tkhq/go-sdk/tree/main/pkg/proofs).
+
+## Pricing
+
+TVC pricing has two components:
+* A fixed per-month platform fee.
+* Variable pricing based on wall-clock enclave uptime
+
+Get in touch with us for more details.
+
+## Getting access to TVC
+
+TVC is current in Beta. We're working with few customers to build the platform and improve it as we go.
+
+If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -30,6 +30,8 @@ Many different types of workloads can benefit from verifiability. Below is a lis
 | Transaction Parsing       | Provide accurate metadata about the effects of a transaction. This is critical for trusted wallet UX. See [VisualSign Parser](https://github.com/anchorageoss/visualsign-parser/).  |
 | Oracles                   | Leverage external data without the overhead of full decentralization, on-chain or off-chain. Replace economic incentives with verifiability. |
 | Blockchain nodes          | Allow for private balance lookups, verifiable mempool inclusion, and more. |
+| Web2 data bridging        | Import and use data from web2 providers (centralized exchange balances, credit scores, X follower counts) in decentralized computation |
+| AI training & inference   | Verifiable training to prove no hidden backdoors; guarantee user prompts remain private |
 | Sequencers                | Prove correct behavior and eliminate the need for challenge periods and economic incentives around them (e.g. [Base sequencer](https://github.com/base/base/tree/main/crates/proof/tee)) |
 | Identity verification     | Prove no identity is leaked as part of the verification process. |
 | VPN nodes                 | Guarantees privacy by proving that forwarded traffic isn't logged anywhere. |
@@ -43,7 +45,7 @@ We’ve engineered TVC to fit within the existing Turnkey products and APIs. You
 ## Applications
 
 TVC is programmable infrastructure, enabling you to create and manage verifiable apps. Each TVC App is deployed on Turnkey infrastructure in the exact same way as Turnkey's own [core enclave apps](https://github.com/tkhq/core-enclaves).
-* TVC Applications are deployed within a Kubernetes cluster operated by Turnkey, using [QuorumOS](https://github.com/tkhq/qos) ("QOS") as a base OS.
+* TVC Applications are deployed within Kubernetes clusters operated by Turnkey, using [QuorumOS](https://github.com/tkhq/qos) ("QOS") as a base OS.
 * Key provisioning, high-availability deployments (minimum of 3 replicas), and in-depth verification workflows are supported by default.
 * Because TVC relies on Turnkey for its own operations, it's possible to use Consensus in the context of TVC activities (with [Turnkey Policies](/concepts/policies) or [Root Quorum](/concepts/users/root-quorum))
 
@@ -60,7 +62,7 @@ Each TVC application can be deployed many times. For every TVC deployment, you w
 
 Once the deployment is submitted and approved, our infrastructure deploys and makes it available on a dedicated subdomain.
 
-| Resource    | Allocation   |
+| Resource    | Default Allocation   |
 | :-----------| :----------- |
 | vCPUs       | 2 |
 | RAM         | 1 GiB |
@@ -98,4 +100,4 @@ Get in touch with us for more details.
 
 ## Getting access to TVC
 
-TVC is currently in Beta. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).
+TVC is currently in private Beta. A select group of design partners are already building on it and getting exclusive access to the latest features and capabilities. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).

--- a/products/verifiable-cloud/overview.mdx
+++ b/products/verifiable-cloud/overview.mdx
@@ -2,25 +2,26 @@
 title: "Overview"
 ---
 
-## What is TVC?
+## What is Turnkey Verifiable Cloud (“TVC”)?
 
-Turnkey Verifiable Cloud ("TVC") is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system.
+Turnkey Verifiable Cloud is a new offering to externalize the [Foundations](https://whitepaper.turnkey.com/foundations) of our TEE-based key management system.
 
 Turnkey started as a key management system with a drastic [threat model](https://whitepaper.turnkey.com/architecture#threat-model), and we placed a bet on TEEs early on. More specifically, Turnkey uses [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/) to deploy all sensitive workloads.
 
-To build the foundations for our key management system we had to dig deep into build systems, deployment tooling, verification tooling, provisioning, performance, and scaling. This work, performed over the course of 3+ years, is valuable and highly general: anyone building within TEEs at scale will encounter similar issues.
+To establish the foundations for our key management system, we had to dig deep into build systems, deployment tooling, verification tooling, provisioning, performance, and scaling.
+This work, developed over 3+ years, is broadly applicable. Any team building at scale within Trusted Execution Environments will encounter the same challenges.
 
-TVC is our attempt at solving these problems transparently for the industry at large, within and outside of crypto. A few of the hard problems solved by TVC:
-* Reproducible builds are crucial to leverage remote attestations (see [this blog post](https://quorum.tkhq.xyz/posts/remote-attestations-useless-without-reproducible-builds/)). We have bootstrapped [StageX](https://stagex.tools), an open-source distro focused on reproducibility. Learn more about it [here](https://quorum.tkhq.xyz/posts/reproducible-builds-made-easy-introducing-stagex/). TVC works with StageX so that you do not have to think about reproducibility. It just works.
-* Packaging applications into EIF files is [easy on the surface](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html) but leaves application developers with load-bearing security decisions: which base OS do I use? How do I handle application upgrades? How do I persist state? Turnkey built [QuorumOS](https://github.com/tkhq/qos) to solve these problems in the context of our own key management platform. TVC is integrated with QOS to handle these problems for you. In TVC you provide the binary application you'd like to run, and we take care of the rest.
-* Running enclaves in Kubernetes is hard. Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling so ensure your application can transparently scale up and down with traffic. We have automated provisioning at boot and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down do not wake up operators in the middle of the night. An enclave going down is automatically replaced and provisioned from already-running enclaves.
-* Verification tooling and workflows are sensitive and hard to get right. Turnkey is regularly audited by top security firms to guarantee verification procedures and the code implementing them remains secure and correct over time.
+TVC solves these problems transparently for the industry at large, within and outside of crypto. A few of the hard problems solved by TVC:
+* **Reproducible builds**: These are crucial to leverage remote attestations (see [this blog post](https://quorum.tkhq.xyz/posts/remote-attestations-useless-without-reproducible-builds/)). To support this, we bootstrapped [StageX](https://stagex.tools), an open-source distro focused on reproducibility. TVC works with StageX so reproducibility is handled for you. Learn more about it [here](https://quorum.tkhq.xyz/posts/reproducible-builds-made-easy-introducing-stagex/).
+* **EIF Files**: Packaging applications into EIF files is [easy on the surface](https://docs.aws.amazon.com/enclaves/latest/user/building-eif.html) but leaves application developers with load-bearing security decisions: which base OS do I use? How do I handle application upgrades? How do I persist state? Turnkey built [QuorumOS](https://github.com/tkhq/qos) to solve these problems in the context of our own key management platform. TVC is integrated with QOS to handle these problems for you. In TVC, you provide the binary application you'd like to run, and we take care of the rest.
+* **Running enclaves in Kubernetes**: Turnkey has invested years of engineering time to get this right. We are running enclaves with autoscaling to ensure your application can transparently scale up and down with traffic. We have automated provisioning and invented [key forwarding](https://github.com/tkhq/qos/blob/main/src/qos_core/KEY_FORWARDING.MD) to ensure enclaves going down are automatically replaced and provisioned from already-running enclaves, Operators do not have to wake up in the middle of the night.
+* **Verification tooling**: Turnkey is regularly audited by top security firms to guarantee verification procedures and the code implementing them remains secure and correct over time.
 
 TVC applications get this (and more!) by default because they run on the same infrastructure as Turnkey's own secure workloads.
 
 ## Use-cases
 
-Many different types of workloads can benefit from verifiability. Below is a list of use-cases we've discussed internally or externally already.
+Many different types of workloads can benefit from verifiability. Below is a list of use cases supported by TVC.
 
 | Workload type             | Advantages to verifiability                                                                         |
 | :-------------------------| :-------------------------------------------------------------------------------------------------- |
@@ -41,7 +42,7 @@ We’ve engineered TVC to fit within the existing Turnkey products and APIs. You
 
 ## Applications
 
-TVC is programmable infrastructure, enabling you to create and manage verifiable apps. Each TVC App is deployed on Turnkey infrastructure in the exact same was as Turnkey's own [core enclave apps](https://github.com/tkhq/core-enclaves).
+TVC is programmable infrastructure, enabling you to create and manage verifiable apps. Each TVC App is deployed on Turnkey infrastructure in the exact same way as Turnkey's own [core enclave apps](https://github.com/tkhq/core-enclaves).
 * TVC Applications are deployed within a Kubernetes cluster operated by Turnkey, using [QuorumOS](https://github.com/tkhq/qos) ("QOS") as a base OS.
 * Key provisioning, high-availability deployments (minimum of 3 replicas), and in-depth verification workflows are supported by default.
 * Because TVC relies on Turnkey for its own operations, it's possible to use Consensus in the context of TVC activities (with [Turnkey Policies](/concepts/policies) or [Root Quorum](/concepts/users/root-quorum))
@@ -52,10 +53,10 @@ A TVC Application has a stable [Quorum Key](https://github.com/tkhq/qos#quorum-k
 
 Each TVC application can be deployed many times. For every TVC deployment, you will specify:
 
-* an OCI image URL (e.g. `ghcr.io/myorg/myrepo:tag@sha256:…`). This container is pulled by our Kubernetes infrastructure. If the container is private, TVC supports uploading encrypted [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-* an executable path + args: within the container, you must indicate where the desired binary lives such that Turnkey’s infrastructure can extract this binary from its OCI container, and run it within a TEE on your behalf.
-* the port on which external requests should be forwarded. This is typically port 3000. For convenience TVC lets you specify different ports for user requests and health requests made by Turnkey infrastructure.
-* your expected executable digest: this is a security measure, to ensure the binary pulled by Turnkey's infrastructure is the binary you expect.
+* An OCI image URL (e.g. `ghcr.io/myorg/myrepo:tag@sha256:…`). This container is pulled by our Kubernetes infrastructure. If the container is private, TVC supports uploading encrypted [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+* An executable path + args: within the container, you must indicate where the desired binary lives such that Turnkey’s infrastructure can extract this binary from its OCI container, and run it within a TEE on your behalf.
+* The port on which external requests should be forwarded. This is typically port 3000. For convenience TVC lets you specify different ports for user requests and health requests made by Turnkey infrastructure.
+* Your expected executable digest: this is a security measure, to ensure the binary pulled by Turnkey's infrastructure is the binary you expect.
 
 Once the deployment is submitted and approved, our infrastructure deploys and makes it available on a dedicated subdomain.
 
@@ -97,6 +98,4 @@ Get in touch with us for more details.
 
 ## Getting access to TVC
 
-TVC is current in Beta. We're working with few customers to build the platform and improve it as we go.
-
-If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).
+TVC is currently in Beta. If you're interested in being an early design partner, or if you want to be notified when TVC is generally available for all, please [join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist).


### PR DESCRIPTION
This PR adds two new pages:
* Overview: outlines TVC and gets into details on what it is, how it works, etc. This is for prospect customers or current customers looking to understand TVC better
* "Build Your First App": focused on getting people oriented and building

These two new pages are in a new "Verifiable Cloud" section under "Products".