### PR TITLE
fix(ip-allowlisting): correct onEvaluationError default from ALLOW to DENY

### DIFF
--- a/security/ip-allowlisting.mdx
+++ b/security/ip-allowlisting.mdx
@@ -29,7 +29,7 @@ This feature is ideal for:
 
 - **The org-level allowlist must be enabled for API key-level rules to take effect.** If the org-level allowlist is disabled, API key-level allowlists are not enforced.
 - **Dashboard actions are never subject to IP allowlisting.** You can always use the Dashboard to manage your configuration, even if you misconfigure your rules.
-- **Unresolvable source IPs default to fail-open.** In rare cases, intermediary infrastructure may prevent Turnkey from resolving a request's source IP. The `onEvaluationError` parameter controls whether these requests are allowed (fail-open) or denied (fail-closed). It defaults to `ALLOW`.
+- **Unresolvable source IPs default to fail-closed.** In rare cases, intermediary infrastructure may prevent Turnkey from resolving a request's source IP. The `onEvaluationError` parameter controls whether these requests are allowed (fail-open) or denied (fail-closed). It defaults to `DENY`.
 
 <Note>
   **IP Allowlisting **is available to [**Enterprise clients**](https://www.turnkey.com/pricing) on the **Scale tier** or higher. If you would like to access this feature please reach out to your Turnkey representative.


### PR DESCRIPTION
## Summary

- Corrects the `onEvaluationError` default value from `ALLOW` to `DENY`, which matches the actual implementation in `set_v1.go`, the DB schema (`DEFAULT 'DENY'`), and `ApplyDefaults()` in the model layer

## Test plan

- [ ] Verify rendered docs show "fail-closed" and "defaults to `DENY`" on the IP allowlisting page

🤖 Generated with [Claude Code](https://claude.com/claude-code)