### PR TITLE
Homepage redesign + Solutions overview page

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // \"\"' | grep -q 'docs\\.json$' && cd /Users/lucy/docs && node scripts/sync-solutions-order.js 2>/dev/null || true",
+            "statusMessage": "Syncing homepage solution order..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs.json
+++ b/docs.json
@@ -56,6 +56,10 @@
         "tab": "Solutions",
         "groups": [
           {
+            "group": "Overview",
+            "pages": ["solutions/overview"]
+          },
+          {
             "group": "Embedded Wallets",
             "pages": [
               "embedded-wallets/overview",

--- a/scripts/sync-solutions-order.js
+++ b/scripts/sync-solutions-order.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Keeps welcome.mdx solution ordering in sync with the Solutions tab in docs.json.
+// Run manually: node scripts/sync-solutions-order.js
+// Also runs automatically via Claude Code hook when docs.json is edited.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DOCS_JSON = path.join(ROOT, 'docs.json');
+const WELCOME_MDX = path.join(ROOT, 'welcome.mdx');
+
+// Display names for each page path as they appear on the homepage.
+// Update this map if a page is renamed or a new use case is added.
+const PAGE_NAMES = {
+  'embedded-wallets/code-examples/embedded-consumer-wallet': 'Embedded Consumer Wallets',
+  'products/embedded-business-wallets/overview': 'Embedded Business Wallets',
+  'embedded-wallets/embedded-waas': 'Wallets-as-a-Service',
+  'products/embedded-wallets/features/agentic-wallets': 'Agentic Wallets',
+  'company-wallets/code-examples/signing-transactions': 'Signing Transactions',
+  'company-wallets/code-examples/smart-contract-management': 'Smart Contract Management',
+  'company-wallets/code-examples/payment-orchestration': 'Payment Orchestration',
+  'company-wallets/use-cases/agentic-wallets': 'Agentic Wallets',
+};
+
+function getUseCases(docsJson, tabName, groupName) {
+  const tab = docsJson.navigation.tabs.find(t => t.tab === tabName);
+  if (!tab) return [];
+  const group = tab.groups.find(g => g.group === groupName);
+  if (!group) return [];
+  const useCasesGroup = group.pages.find(p => typeof p === 'object' && p.group === 'Use cases');
+  if (!useCasesGroup) return [];
+  return useCasesGroup.pages.filter(p => typeof p === 'string' && PAGE_NAMES[p]);
+}
+
+function buildList(pages) {
+  return pages.map((p, i) => `    ${i + 1}. [${PAGE_NAMES[p]}](/${p})`).join('\n');
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceSection(content, marker, newList) {
+  const start = `{/* sync-start: ${marker} */}`;
+  const end = `{/* sync-end: ${marker} */}`;
+  const re = new RegExp(`${escapeRegex(start)}[\\s\\S]*?${escapeRegex(end)}`);
+  const replacement = `${start}\n${newList}\n  ${end}`;
+  if (!re.test(content)) {
+    console.warn(`Warning: marker "${marker}" not found in welcome.mdx — skipping.`);
+    return content;
+  }
+  return content.replace(re, replacement);
+}
+
+const docsJson = JSON.parse(fs.readFileSync(DOCS_JSON, 'utf8'));
+const embeddedPages = getUseCases(docsJson, 'Solutions', 'Embedded Wallets');
+const companyPages  = getUseCases(docsJson, 'Solutions', 'Company Wallets');
+
+let welcome = fs.readFileSync(WELCOME_MDX, 'utf8');
+welcome = replaceSection(welcome, 'embedded-wallets-use-cases', buildList(embeddedPages));
+welcome = replaceSection(welcome, 'company-wallets-use-cases',  buildList(companyPages));
+fs.writeFileSync(WELCOME_MDX, welcome);
+
+console.log('✓ welcome.mdx solution ordering synced from docs.json');

--- a/solutions/overview.mdx
+++ b/solutions/overview.mdx
@@ -1,8 +1,69 @@
 ---
-title: "ROUTER PAGE"
-description: "PLACEHOLDER LANDING PAGE"
+title: "Introducing Solutions"
+description: "Structured starting points for building onchain with Turnkey"
 ---
 
-# Solutions
+To help you ship quickly, we've packaged common patterns like wallet provisioning, policy enforcement, and transaction flows into easy integration paths called solutions. Each solution is built on Turnkey's underlying primitives, so you're never locked into a rigid workflow and can always go deeper when you need more flexibility.
 
-> **This is a placeholder landing page.** Content will be written in a future phase.
+Whether you're building consumer apps, business tooling, or AI-powered systems, there's a solution designed for your use case.
+
+---
+
+## Embedded Wallets
+
+Wallet experiences built directly into your product. Users authenticate with email, passkeys, or social login — you control the UX.
+
+<CardGroup cols={2}>
+  <Card title="Embedded Consumer Wallets" icon="user" href="/embedded-wallets/code-examples/embedded-consumer-wallet">
+    Non-custodial wallets with plug-and-play UI for consumer onboarding.
+  </Card>
+  <Card title="Embedded Business Wallets" icon="users" href="/products/embedded-business-wallets/overview">
+    Multi-user access with policy controls and automated payment flows.
+  </Card>
+  <Card title="Agentic Wallets" icon="robot" href="/products/embedded-wallets/features/agentic-wallets">
+    Transaction signing and smart contract interaction for AI agents.
+  </Card>
+  <Card title="Embedded WaaS" icon="building" href="/embedded-wallets/embedded-waas">
+    White-labeled wallets with isolated user environments for your own wallet product.
+  </Card>
+</CardGroup>
+
+---
+
+## Company Wallets
+
+Wallets your organization operates for onchain automation — high-volume signing with programmable controls.
+
+<CardGroup cols={2}>
+  <Card title="Payment Orchestration" icon="arrow-right-arrow-left" href="/company-wallets/code-examples/payment-orchestration">
+    Automated stablecoin movement flows at scale.
+  </Card>
+  <Card title="Smart Contract Management" icon="file-code" href="/company-wallets/code-examples/smart-contract-management">
+    Production infrastructure for governing smart contract execution.
+  </Card>
+</CardGroup>
+
+---
+
+## Key Management
+
+Enterprise-grade security for your most sensitive keys — hardware-backed with programmable access controls.
+
+<CardGroup cols={2}>
+  <Card title="Encryption Key Storage" icon="key" href="/products/key-management/examples/encryption-key-storage">
+    Secure key generation and policy-controlled access for encrypted data.
+  </Card>
+  <Card title="Enterprise Disaster Recovery" icon="shield-check" href="/products/key-management/examples/enterprise-disaster-recovery">
+    Non-custodial wallet recovery with instant policy enforcement.
+  </Card>
+</CardGroup>
+
+---
+
+## Turnkey Verifiable Cloud
+
+Run code inside hardware-isolated enclaves with verifiable computation guarantees.
+
+<Card title="Verifiable Cloud" icon="cloud" href="/products/verifiable-cloud/overview">
+  Purpose-built for applications where trust and auditability are non-negotiable.
+</Card>

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -4,14 +4,16 @@ description: "Secure, flexible, and scalable wallet infrastructure"
 mode: "custom"
 ---
 
-<div style={{maxWidth: '900px', margin: '0 auto', padding: '3rem 2rem 4rem'}}>
+<div style={{maxWidth: '830px', margin: '0 auto', padding: '3rem 2rem 4rem'}}>
+
+<style>{`@media (min-width: 830px) { .hero-break { display: block; } }`}</style>
 
 <div style={{textAlign: 'center', marginBottom: '3rem'}}>
 
-<h1 style={{fontSize: '2.75rem', fontWeight: '800', lineHeight: '1.15', marginBottom: '1rem', color: '#6a5bf5'}}>Turnkey: Secure, flexible, and scalable wallet infrastructure</h1>
+<h1 style={{fontSize: '2.75rem', fontWeight: '800', lineHeight: '1.15', marginBottom: '1.25rem', color: '#6a5bf5'}}>Secure, flexible, and scalable <span className="hero-break min-[830px]:block">wallet infrastructure</span></h1>
 
-<p style={{color: '#6b7280', fontSize: '1.0625rem', maxWidth: '620px', margin: '0 auto 2rem', lineHeight: '1.75'}}>
-  Turnkey provides the infrastructure to create and manage wallets, sign transactions, and secure cryptographic keys — where every key operation is hardware-isolated, policy-governed, and cryptographically auditable. Build on a foundation where security isn't a tradeoff.
+<p style={{color: '#6b7280', fontSize: '1rem', lineHeight: '1.75', maxWidth: '700px', margin: '0 auto 1.5rem'}}>
+  Turnkey is infrastructure for generating wallets and keys, signing transactions, and controlling who can use them, when, and how. Private keys are secured in hardware-isolated enclaves and never exposed — not even to Turnkey.
 </p>
 
 <div
@@ -36,109 +38,132 @@ mode: "custom"
   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth="2">
     <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
   </svg>
-  <span style={{flex: 1, color: '#9ca3af', fontSize: '16px'}}>Search the docs...</span>
+  <span style={{flex: 1, color: '#9ca3af', fontSize: '16px'}}>Search Turnkey's docs...</span>
   <kbd style={{fontSize: '12px', color: '#6b7280', border: '1px solid #e5e7eb', borderRadius: '4px', padding: '2px 8px', backgroundColor: 'white'}}>⌘K</kbd>
 </div>
 
 </div>
 
-<hr />
+<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1.25rem'}}>Build with Turnkey</h2>
 
-<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1rem'}}>Explore Turnkey's products</h2>
+<div style={{display: 'flex', alignItems: 'center', gap: '3rem'}}>
+
+  <div style={{flex: '0 0 40%', display: 'flex', flexDirection: 'column', gap: '8px'}}>
+    <div style={{background: '#6a5bf5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+      <div>
+        <div style={{fontWeight: '600', fontSize: '0.875rem'}}>Solutions</div>
+        <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>Pre-built patterns for common use cases</div>
+      </div>
+    </div>
+    <div style={{background: '#7c6ef5', color: 'white', padding: '10px 16px', borderRadius: '8px'}}>
+      <div style={{fontWeight: '600', fontSize: '0.875rem'}}>SDK</div>
+      <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>TypeScript, React, React Native, and more</div>
+    </div>
+    <div style={{background: '#4f46e5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+      <div>
+        <div style={{fontWeight: '600', fontSize: '0.875rem'}}>API</div>
+        <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>REST API for complete control over every operation</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <p style={{color: '#6b7280', lineHeight: '1.75', marginBottom: '1.25rem', marginTop: '0'}}>
+      Build at whichever level best meets your needs. Start with Solutions for common patterns, go deeper with our SDKs for more control, or reach all the way down to the API for complete flexibility. The full stack is always available.
+    </p>
+    <div style={{display: 'flex', flexDirection: 'column', gap: '0.5rem'}}>
+      <a href="/home" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Go to Documentation →</a>
+      <a href="/concepts/overview" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Learn how Turnkey works →</a>
+      <a href="/getting-started/quickstart" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Start building →</a>
+    </div>
+  </div>
+
+</div>
+
+<div style={{marginBottom: '3rem'}} />
+
+<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1.25rem'}}>Explore our solutions</h2>
 
 <CardGroup cols={2}>
 
-  <Card
-    title="Embedded Wallets"
-    icon="wallet"
-    href="/embedded-wallets/overview"
-  >
-    **Wallet experiences built into your product**
+  <Card title="Embedded Wallets" icon="wallet">
+    Build wallets directly into your app. Users authenticate with email, passkeys, or social login. You control the experience.
 
-    Build wallets directly into your app — for consumers, business accounts, or as the foundation for your own wallet product. Users authenticate with email, passkeys, or social login. You control the experience.
-
-    {/*
-      ⚠️ INTERNAL NOTE — NOT FOR PUBLICATION
-      Are embedded wallets always non-custodial? Previous description said "non-custodial"
-      but the product supports non-custodial and hybrid custody models.
-      Needs stakeholder confirmation before finalizing this description.
-    */}
+    {/* sync-start: embedded-wallets-use-cases */}
+    1. [Embedded Consumer Wallets](/embedded-wallets/code-examples/embedded-consumer-wallet)
+    2. [Embedded Business Wallets](/products/embedded-business-wallets/overview)
+    3. [Wallets-as-a-Service](/embedded-wallets/embedded-waas)
+    4. [Agentic Wallets](/products/embedded-wallets/features/agentic-wallets)
+  {/* sync-end: embedded-wallets-use-cases */}
   </Card>
 
-  <Card
-    title="Company Wallets"
-    icon="building"
-    href="/company-wallets/overview"
-  >
-    **Wallets your organization operates for onchain automation**
+  <Card title="Company Wallets" icon="building">
+    Automate your onchain operations with wallets, keys and programmable controls purpose built for scale.
 
-    Run high-volume signing workflows with programmable controls — spending limits, multi-party approvals, role-based access, and automated policy execution. Purpose-built for teams that need to operate onchain at scale.
-  </Card>
-
-  <Card
-    title="Key Management"
-    icon="key"
-    href="/products/key-management/overview"
-  >
-    **Enterprise-grade security for your most sensitive keys**
-
-    Hardware-backed key storage with programmable access controls, quorum approvals, and tamper-evident audit logs. The security model your most critical infrastructure deserves.
-  </Card>
-
-  <Card
-    title="Verifiable Cloud"
-    icon="shield-check"
-    href="/tvc/overview"
-  >
-    **Run code inside hardware-isolated enclaves** `Beta`
-
-    Execute workloads with verifiable computation guarantees — built for applications where trust and auditability are non-negotiable.
+    {/* sync-start: company-wallets-use-cases */}
+    1. [Signing Transactions](/company-wallets/code-examples/signing-transactions)
+    2. [Smart Contract Management](/company-wallets/code-examples/smart-contract-management)
+    3. [Payment Orchestration](/company-wallets/code-examples/payment-orchestration)
+    4. [Agentic Wallets](/company-wallets/use-cases/agentic-wallets)
+  {/* sync-end: company-wallets-use-cases */}
   </Card>
 
 </CardGroup>
 
-<hr />
+<div style={{backgroundColor: '#f9fafb', borderRadius: '12px', border: '1px solid #e5e7eb', marginTop: '12px', padding: '1.5rem'}}>
+  <div style={{fontWeight: '600', fontSize: '0.95rem', marginBottom: '1rem'}}>Other solutions</div>
+  <div style={{display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px'}}>
+    <a href="/products/key-management/overview" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>1.</div>
+      <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Key Management</div>
+      <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Enterprise-grade key security</div>
+    </a>
+    <a href="/products/key-management/examples/encryption-key-storage" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>2.</div>
+      <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Encryption Key Storage</div>
+      <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Policy-controlled key access</div>
+    </a>
+    <a href="/products/key-management/examples/enterprise-disaster-recovery" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>3.</div>
+      <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Enterprise Disaster Recovery</div>
+      <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Non-custodial wallet recovery</div>
+    </a>
+    <a href="/products/verifiable-cloud/overview" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>4.</div>
+      <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Verifiable Cloud <span style={{fontSize: '0.7rem', background: '#ede9fe', color: '#6a5bf5', borderRadius: '4px', padding: '1px 6px', marginLeft: '4px'}}>Beta</span></div>
+      <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Hardware-isolated compute</div>
+    </a>
+  </div>
+</div>
 
-<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1rem'}}>How Turnkey works</h2>
+<div style={{marginBottom: '3rem'}} />
 
-<Card
-  title="How Turnkey works"
-  icon="book-open"
-  href="/concepts/overview"
->
-  Understand the core architecture behind Turnkey's key infrastructure.
-</Card>
+<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1.25rem'}}>Explore our features</h2>
 
-<hr />
-
-<h2 style={{fontSize: '1.5rem', fontWeight: '700', marginBottom: '1rem'}}>Start building</h2>
-
-<CardGroup cols={2}>
-
-  <Card
-    title="Account setup"
-    icon="circle-play"
-    href="/getting-started/quickstart"
-  >
-    Create your organization and generate an API keypair — the two steps every Turnkey integration starts with.
-  </Card>
-
-  <Card
-    title="Embedded Wallets quickstart"
-    icon="code"
-    href="/getting-started/embedded-wallet-quickstart"
-  >
-    Jump into code with a step-by-step guide for building embedded wallets.
-  </Card>
-
-  <Card
-    title="Verifiable Cloud quickstart"
-    icon="code"
-    href="/getting-started/verifiable-cloud-quickstart"
-  >
-    Get started running workloads inside Turnkey's secure enclave infrastructure.
-  </Card>
-
+<CardGroup cols={3}>
+  <Card title="Embedded wallet kit" icon="wallet" iconType="duotone" horizontal href="/reference/embedded-wallet-kit" />
+  <Card title="Authentication" icon="lock" iconType="duotone" horizontal href="/authentication/overview" />
+  <Card title="Delegated access" icon="door-closed" iconType="duotone" horizontal href="/concepts/policies/delegated-access-frontend" />
+  <Card title="Agentic wallets" icon="robot" iconType="duotone" horizontal href="/products/embedded-wallets/features/agentic-wallets" />
+  <Card title="Transaction management" icon="money-bill-transfer" iconType="duotone" horizontal href="/concepts/transaction-management" />
+  <Card title="Policy engine" icon="gears" iconType="duotone" horizontal href="/concepts/policies/overview" />
+  <Card title="Multichain support" icon="diagram-project" iconType="duotone" horizontal href="/products/embedded-wallets/features/multi-chain-support" />
+  <Card title="Pre-generated wallets" icon="wallet" iconType="duotone" horizontal href="/wallets/pregenerated-wallets" />
+  <Card title="Sessions" icon="clock" iconType="duotone" horizontal href="/authentication/sessions" />
+  <Card title="Account abstraction wallets" icon="users-gear" iconType="duotone" horizontal href="/reference/aa-wallets" />
+  <Card title="Import wallets and keys" icon="file-import" iconType="duotone" horizontal href="/wallets/import-wallets" />
+  <Card title="Export wallets and keys" icon="file-export" iconType="duotone" horizontal href="/wallets/export-wallets" />
+  <Card title="Claim links" icon="link" iconType="duotone" horizontal href="/wallets/claim-links" />
+  <Card title="Wagmi" icon="plug" iconType="duotone" horizontal href="/wallets/wagmi" />
+  <Card title="Fiat onramp" icon="money-bill-transfer" iconType="duotone" horizontal href="/wallets/fiat-on-ramp" />
+  <Card title="Auth proxy" icon="server" iconType="duotone" horizontal href="/reference/auth-proxy" />
 </CardGroup>
+
+<div style={{padding: '1.75rem 2rem', background: 'linear-gradient(135deg, #6a5bf5 0%, #4f46e5 100%)', borderRadius: '12px'}}>
+  <div style={{fontSize: '0.875rem', color: 'rgba(255,255,255,0.8)', marginBottom: '0.75rem'}}>Read our whitepaper for an in-depth look at Turnkey's security model and verifiable key management infrastructure.</div>
+  <a href="https://whitepaper.turnkey.com/" style={{color: 'white', fontWeight: '600', textDecoration: 'none', fontSize: '0.9rem'}}>
+    Read the Turnkey Whitepaper →
+  </a>
+</div>
 
 </div>


### PR DESCRIPTION
## Summary

- **Homepage (`welcome.mdx`)**: Added a 2-sentence mental model blurb above the search bar; moved "Build with Turnkey" section (layer visual + nav links) to the top of the page for immediate routing; added Other Solutions grid, feature card grid, and a branded purple whitepaper CTA at the bottom
- **Solutions overview (`solutions/overview.mdx`)**: New page with updated intro copy and CardGroups organized by product category
- **Sync tooling**: Added `scripts/sync-solutions-order.js` and a Claude Code hook (`.claude/settings.json`) to keep homepage use case lists automatically in sync with docs.json nav ordering

## Test plan

- [ ] Preview homepage at root URL — verify blurb, Build with Turnkey, and solutions sections render correctly
- [ ] Verify whitepaper tile renders with purple gradient
- [ ] Check Solutions > Introducing Solutions page renders with updated copy
- [ ] Verify "Build with Turnkey" links (Documentation, How Turnkey works, Start building) resolve correctly
- [ ] Confirm responsive line break in purple H1 fires at correct breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)