### PR TITLE
Homepage tweaks: links, Other Solutions cleanup

### DIFF
--- a/welcome.mdx
+++ b/welcome.mdx
@@ -49,22 +49,22 @@ mode: "custom"
 <div style={{display: 'flex', alignItems: 'center', gap: '3rem'}}>
 
   <div style={{flex: '0 0 40%', display: 'flex', flexDirection: 'column', gap: '8px'}}>
-    <div style={{background: '#6a5bf5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+    <a href="/solutions/overview" style={{textDecoration: 'none', background: '#6a5bf5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
       <div>
         <div style={{fontWeight: '600', fontSize: '0.875rem'}}>Solutions</div>
         <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>Pre-built patterns for common use cases</div>
       </div>
-    </div>
-    <div style={{background: '#7c6ef5', color: 'white', padding: '10px 16px', borderRadius: '8px'}}>
+    </a>
+    <a href="/sdks/introduction" style={{textDecoration: 'none', background: '#7c6ef5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'block'}}>
       <div style={{fontWeight: '600', fontSize: '0.875rem'}}>SDK</div>
       <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>TypeScript, React, React Native, and more</div>
-    </div>
-    <div style={{background: '#4f46e5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
+    </a>
+    <a href="/developer-reference/api-overview/intro" style={{textDecoration: 'none', background: '#4f46e5', color: 'white', padding: '10px 16px', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
       <div>
         <div style={{fontWeight: '600', fontSize: '0.875rem'}}>API</div>
         <div style={{fontSize: '0.75rem', opacity: '0.8', marginTop: '2px'}}>REST API for complete control over every operation</div>
       </div>
-    </div>
+    </a>
   </div>
 
   <div>
@@ -72,7 +72,6 @@ mode: "custom"
       Build at whichever level best meets your needs. Start with Solutions for common patterns, go deeper with our SDKs for more control, or reach all the way down to the API for complete flexibility. The full stack is always available.
     </p>
     <div style={{display: 'flex', flexDirection: 'column', gap: '0.5rem'}}>
-      <a href="/home" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Go to Documentation →</a>
       <a href="/home" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Learn how Turnkey works →</a>
       <a href="/getting-started/quickstart" style={{color: '#6a5bf5', fontWeight: '600', textDecoration: 'none', fontSize: '0.95rem'}}>Start building →</a>
     </div>
@@ -86,7 +85,7 @@ mode: "custom"
 
 <CardGroup cols={2}>
 
-  <Card title="Embedded Wallets" icon="wallet">
+  <Card title={<a href="/embedded-wallets/overview" style={{color: 'inherit', textDecoration: 'none'}}>Embedded Wallets</a>} icon="wallet">
     Build wallets directly into your app. Users authenticate with email, passkeys, or social login. You control the experience.
 
     {/* sync-start: embedded-wallets-use-cases */}
@@ -97,7 +96,7 @@ mode: "custom"
   {/* sync-end: embedded-wallets-use-cases */}
   </Card>
 
-  <Card title="Company Wallets" icon="building">
+  <Card title={<a href="/company-wallets/overview" style={{color: 'inherit', textDecoration: 'none'}}>Company Wallets</a>} icon="building">
     Automate your onchain operations with wallets, keys and programmable controls purpose built for scale.
 
     {/* sync-start: company-wallets-use-cases */}
@@ -112,24 +111,19 @@ mode: "custom"
 
 <div style={{backgroundColor: '#f9fafb', borderRadius: '12px', border: '1px solid #e5e7eb', marginTop: '12px', padding: '1.5rem'}}>
   <div style={{fontWeight: '600', fontSize: '0.95rem', marginBottom: '1rem'}}>Other solutions</div>
-  <div style={{display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px'}}>
-    <a href="/products/key-management/overview" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
-      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>1.</div>
-      <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Key Management</div>
-      <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Enterprise-grade key security</div>
-    </a>
+  <div style={{display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px'}}>
     <a href="/products/key-management/examples/encryption-key-storage" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
-      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>2.</div>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>1.</div>
       <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Encryption Key Storage</div>
       <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Policy-controlled key access</div>
     </a>
     <a href="/products/key-management/examples/enterprise-disaster-recovery" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
-      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>3.</div>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>2.</div>
       <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Enterprise Disaster Recovery</div>
       <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Non-custodial wallet recovery</div>
     </a>
     <a href="/products/verifiable-cloud/overview" style={{textDecoration: 'none', color: 'inherit', padding: '1rem', borderRadius: '8px', border: '1px solid #e5e7eb', backgroundColor: 'white', display: 'block'}}>
-      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>4.</div>
+      <div style={{fontSize: '0.75rem', color: '#9ca3af', marginBottom: '4px'}}>3.</div>
       <div style={{fontWeight: '600', fontSize: '0.9rem', marginBottom: '4px'}}>Verifiable Cloud <span style={{fontSize: '0.7rem', background: '#ede9fe', color: '#6a5bf5', borderRadius: '4px', padding: '1px 6px', marginLeft: '4px'}}>Beta</span></div>
       <div style={{fontSize: '0.8rem', color: '#6b7280'}}>Hardware-isolated compute</div>
     </a>
@@ -161,7 +155,7 @@ mode: "custom"
 
 <div style={{padding: '1.75rem 2rem', background: 'linear-gradient(135deg, #6a5bf5 0%, #4f46e5 100%)', borderRadius: '12px'}}>
   <div style={{fontSize: '0.875rem', color: 'rgba(255,255,255,0.8)', marginBottom: '0.75rem'}}>Read our whitepaper for an in-depth look at Turnkey's security model and verifiable key management infrastructure.</div>
-  <a href="https://whitepaper.turnkey.com/" style={{color: 'white', fontWeight: '600', textDecoration: 'none', fontSize: '0.9rem'}}>
+  <a href="https://whitepaper.turnkey.com/" target="_blank" rel="noopener noreferrer" style={{color: 'white', fontWeight: '600', textDecoration: 'none', fontSize: '0.9rem'}}>
     Read the Turnkey Whitepaper →
   </a>
 </div>


### PR DESCRIPTION
## Summary

- Consolidated duplicate "Go to Documentation" / "Learn how Turnkey works" links into a single "Learn how Turnkey works" → About Turnkey page
- Linked Solutions, SDK, and API layer boxes to their respective pages
- Linked Embedded Wallets and Company Wallets card titles to their overview pages (formatting unchanged)
- Updated API box link to API Reference > Overview > Introduction
- Whitepaper link now opens in a new tab
- Removed Key Management tile from Other Solutions grid; updated to 3-column layout

## Test plan

- [ ] Verify all 3 layer boxes (Solutions, SDK, API) navigate to correct pages
- [ ] Verify Embedded Wallets and Company Wallets titles are clickable without visual change
- [ ] Verify "Learn how Turnkey works" goes to About Turnkey page
- [ ] Verify whitepaper opens in new tab
- [ ] Confirm Other Solutions shows 3 tiles in correct layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)