### PR TITLE
Add agent skills page and Using LLMs nav group

### DIFF
--- a/ai/skills.mdx
+++ b/ai/skills.mdx
@@ -1,0 +1,70 @@
+---
+title: "Agent Skills"
+description: "Opinionated instructions that tell AI agents how to interact with Turnkey through conversation, not code."
+---
+
+Each agent skill is a `SKILL.md` file with opinionated, step-by-step instructions for a specific Turnkey operation. Instead of an agent reasoning about API docs, parameter formatting, and chain-specific details on its own, skills give it exactly what it needs to execute correctly. Skills work with Claude Code, OpenAI, and other third-party agent frameworks.
+
+Skills are for interacting with Turnkey directly through an AI assistant, not for building the application layer on top of Turnkey. If you're using a coding agent to develop a Turnkey integration, connect it to the [Docs MCP server](/developer-reference/using-llms) instead.
+
+Skills are open source at [**tkhq/turnkey-agent-skills**](https://github.com/tkhq/turnkey-agent-skills) on GitHub.
+
+## Use cases
+
+Skills are composable. Each skill handles a single domain (wallets, signing, policies, etc.) and can be combined for any workflow. Common starting points:
+
+| Use case | What you can do | Start with |
+| :--- | :--- | :--- |
+| **Explore and test** | Create wallets, sign transactions, and set policies without writing integration code | `getting-started` |
+| **Administer your org** | Manage users, rotate API keys, configure policies, and monitor activities conversationally | `managing-users`, `managing-policies` |
+| **Provision autonomous agents** | Set up a scoped wallet with constrained credentials and governance policies for onchain automation | `provisioning-agent` |
+
+## Credentials and security
+
+<Warning>
+  Read the following carefully before giving any AI agent access to your Turnkey organization.
+</Warning>
+
+- **LLMs can misinterpret instructions or execute unintended actions.** Scoped credentials ensure mistakes are bounded. Turnkey policies are the technical enforcement mechanism.
+- **Root credentials are dangerous to give to an AI agent.** A root API key bypasses all policies and has full access to your organization. Root credentials may be acceptable for testing — evaluate the risk before using them in production.
+  - For best security, create a non-root user with specifically scoped permissions and approval flows. When testing against a non-production organization, root credentials may be more acceptable.
+- **Never test against wallets holding real funds** unless you have appropriate safeguards in place (scoped credentials, spending caps, destination allowlists).
+- **Turnkey operates based on a [shared responsibility model](/security/shared-responsibility-model).** Turnkey secures the platform, including enclaves, the policy engine, and key confidentiality. You are responsible for how you configure your organization, scope credentials, and author policies. This applies doubly when delegating actions to an AI agent.
+
+All skills require an API key pair and organization ID from the [Turnkey Dashboard](https://app.turnkey.com) (**Settings > API Keys**). Which credentials you use depends on your setup:
+
+| Setup | Credential type | When to use |
+| :--- | :--- | :--- |
+| **Interactive assistant** (human approves each action) | Root API key (with extreme caution) or a scoped, non-root API key | Organization administration, testing, and exploration. Human should review every action before it executes. |
+| **Autonomous agent** (acts without human review) | Scoped, non-root API key | Production automation. **Never use root credentials for autonomous agents.** Root keys bypass all policies. Create a non-root user with scoped policies instead. See [Agentic Wallets](/company-wallets/use-cases/agentic-wallets) and the `provisioning-agent` skill. |
+
+## Available skills
+
+Skills are organized into **workflows** (guided multi-step procedures) and **primitives** (individual operations).
+
+### Workflows
+
+| Skill | Description |
+| :--- | :--- |
+| **Getting Started** | Day-0 onboarding: verify credentials, create your first wallet |
+| **Provisioning Agent** | Create a scoped agent with constrained credentials and policies |
+| **Managing Agent** | Debug denied transactions, rotate keys, update agent policies |
+
+### Primitives
+
+| Skill | Description |
+| :--- | :--- |
+| **Managing Wallets** | Create wallets, derive addresses, add chains, import/export |
+| **Signing Transactions** | Sign and broadcast on any supported chain (EVM, Solana, Bitcoin, and more) |
+| **Managing Users** | Create users, rotate API keys, manage user tags |
+| **Managing Policies** | Access control, spending limits, allowlists, multi-party approval |
+| **Monitoring Activities** | Activity status, consensus approvals, audit logs |
+
+## Getting started
+
+Clone the repo and point your AI assistant at the skill files:
+
+```bash
+git clone https://github.com/tkhq/turnkey-agent-skills.git
+cd turnkey-agent-skills
+```

--- a/developer-reference/using-llms.mdx
+++ b/developer-reference/using-llms.mdx
@@ -1,8 +1,6 @@
 ---
-title: "Using LLMs"
+title: "Using AI to integrate to Turnkey"
 ---
-
-### Using AI to integrate Turnkey
 
 Turnkey documentation is now AI-enhanced. Whether you're using ChatGPT, Claude, or a custom LLM integration,
 we've made it easy to feed Turnkey docs directly into your models—and even easier to surface relevant answers programmatically or in your dev tools.

--- a/docs.json
+++ b/docs.json
@@ -323,7 +323,13 @@
             "group": "Developers",
             "pages": [
               "getting-started/examples",
-              "developer-reference/using-llms",
+              {
+                "group": "Using LLMs",
+                "pages": [
+                  "developer-reference/using-llms",
+                  "ai/skills"
+                ]
+              },
               {
                 "group": "API overview",
                 "pages": [


### PR DESCRIPTION
## Summary
- Added the agent skills documentation page and created a "Using LLMs" grouping in the doc nav
- Renamed the "Using LLMs" sub-page title to "Using AI to integrate to Turnkey" and removed duplicate H1

## Test plan
- [ ] Verify the "Using LLMs" dropdown appears in the sidebar under Developers
- [ ] Verify the Agent Skills page renders correctly
- [ ] Verify the "Using AI to integrate to Turnkey" page title displays without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)