### PR TITLE
docs: update wallet.id keyword to include CREATE_WALLET_ACCOUNTS

### DIFF
--- a/concepts/policies/examples/access-control.mdx
+++ b/concepts/policies/examples/access-control.mdx
@@ -15,6 +15,17 @@ sidebarTitle: "Access control"
 }
 ```
 
+#### Restrict which wallets a user can add accounts to
+
+```json
+{
+  "policyName": "Allow user <USER_ID> to create accounts only on <WALLET_ID>",
+  "effect": "EFFECT_ALLOW",
+  "consensus": "approvers.any(user, user.id == '<USER_ID>')",
+  "condition": "activity.type == 'ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS' && wallet.id == '<WALLET_ID>'"
+}
+```
+
 #### Allow users with a specific tag to create users
 
 ```json

--- a/concepts/policies/language.mdx
+++ b/concepts/policies/language.mdx
@@ -48,7 +48,7 @@ Keywords are reserved words that are dynamically interchanged for real values at
 | **tron.tx**                    | TronTransaction      | The parsed Tron transaction payload (see Appendix below)                    |
 | **bitcoin.tx**                 | BitcoinTransaction   | The parsed Bitcoin transaction payload (see Appendix below)                 |
 | **tempo.tx**                   | TempoTransaction     | The parsed Tempo transaction payload (see Appendix below)                   |
-| **wallet**                     | Wallet               | The target wallet used in sign + export requests                            |
+| **wallet**                     | Wallet               | The target wallet used in sign, export, and create wallet accounts requests |
 | **wallets**                    | list\<Wallet\>       | The target wallets associated with requests involving with multiple wallets |
 | **private_key**                | PrivateKey           | The target private key used in sign + export requests                       |
 | **wallet_account**             | WalletAccount        | The target wallet account used in sign + export requests                    |


### PR DESCRIPTION
## Summary
- Updates the `wallet` keyword description in the policy language reference to reflect that `wallet.id` now works with `ACTIVITY_TYPE_CREATE_WALLET_ACCOUNTS` (not just sign + export)
- Adds a new access control policy example showing how to restrict which wallets a user can add accounts to

## Context
Reflects [tkhq/mono#6492](https://github.com/tkhq/mono/pull/6492) which added `CreateWalletAccountsIntent` to the `wallet.id` keyword match in the UMP evaluator.

## Test plan
- [ ] Verify policy language keyword table renders correctly
- [ ] Verify new access control example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)