### PR TITLE
Balance Webhooks: Confirmation Thresholds and Finalized Payload Example

### DIFF
--- a/snippets/shared/balance-concepts.mdx
+++ b/snippets/shared/balance-concepts.mdx
@@ -118,17 +118,17 @@ The `balances:finalized` webhook fires once the block containing a transaction h
 
 | Network             | CAIP-2 Identifier                          | Confirmations |
 | :------------------ | :----------------------------------------- | ------------: |
-| Ethereum            | `eip155:1`                                 |            32 |
-| Base                | `eip155:8453`                              |            10 |
-| Polygon             | `eip155:137`                               |            30 |
-| Arbitrum            | `eip155:42161`                             |            10 |
-| BNB Chain           | `eip155:56`                                |            30 |
-| Ethereum (Sepolia)  | `eip155:11155111`                          |            12 |
-| Base (Sepolia)      | `eip155:84532`                             |             5 |
-| Polygon (Amoy)      | `eip155:80002`                             |            12 |
-| Arbitrum (Sepolia)  | `eip155:421614`                            |             5 |
-| BNB Chain (Testnet) | `eip155:97`                                |            12 |
-| Meld                | `eip155:5042002`                           |             2 |
+| Ethereum Mainnet    | `eip155:1`                                 |            32 |
+| Ethereum Sepolia    | `eip155:11155111`                          |            12 |
+| Base Mainnet        | `eip155:8453`                              |            10 |
+| Base Sepolia        | `eip155:84532`                             |             5 |
+| Polygon Mainnet     | `eip155:137`                               |            30 |
+| Polygon Amoy        | `eip155:80002`                             |            12 |
+| Arbitrum Mainnet    | `eip155:42161`                             |            10 |
+| Arbitrum Sepolia    | `eip155:421614`                            |             5 |
+| BSC Mainnet         | `eip155:56`                                |            30 |
+| BSC Testnet         | `eip155:97`                                |            12 |
+| Arc Testnet         | `eip155:5042002`                           |             2 |
 | Solana mainnet      | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`  |            32 |
 | Solana devnet       | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`  |            32 |
 

--- a/snippets/shared/balance-concepts.mdx
+++ b/snippets/shared/balance-concepts.mdx
@@ -126,9 +126,6 @@ The `balances:finalized` webhook fires once the block containing a transaction h
 | Polygon Amoy        | `eip155:80002`                             |            12 |
 | Arbitrum Mainnet    | `eip155:42161`                             |            10 |
 | Arbitrum Sepolia    | `eip155:421614`                            |             5 |
-| BSC Mainnet         | `eip155:56`                                |            30 |
-| BSC Testnet         | `eip155:97`                                |            12 |
-| Arc Testnet         | `eip155:5042002`                           |             2 |
 | Solana mainnet      | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`  |            32 |
 | Solana devnet       | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`  |            32 |
 

--- a/snippets/shared/balance-concepts.mdx
+++ b/snippets/shared/balance-concepts.mdx
@@ -112,13 +112,33 @@ Balance webhooks are currently supported on:
 
 > Interested in another chain? Reach out to us!
 
+#### Confirmation thresholds
+
+The `balances:finalized` webhook fires once the block containing a transaction has reached a chain-specific number of confirmations. The table below lists the confirmation threshold Turnkey uses for each supported network:
+
+| Network             | CAIP-2 Identifier                          | Confirmations |
+| :------------------ | :----------------------------------------- | ------------: |
+| Ethereum            | `eip155:1`                                 |            32 |
+| Base                | `eip155:8453`                              |            10 |
+| Polygon             | `eip155:137`                               |            30 |
+| Arbitrum            | `eip155:42161`                             |            10 |
+| BNB Chain           | `eip155:56`                                |            30 |
+| Ethereum (Sepolia)  | `eip155:11155111`                          |            12 |
+| Base (Sepolia)      | `eip155:84532`                             |             5 |
+| Polygon (Amoy)      | `eip155:80002`                             |            12 |
+| Arbitrum (Sepolia)  | `eip155:421614`                            |             5 |
+| BNB Chain (Testnet) | `eip155:97`                                |            12 |
+| Meld                | `eip155:5042002`                           |             2 |
+| Solana mainnet      | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`  |            32 |
+| Solana devnet       | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`  |            32 |
+
 #### Delivery payload
 
 Each delivery corresponds to a single balance-change event: one address, one operation (`deposit` or
 `withdraw`), and one asset. Because a single transaction can affect multiple addresses or assets, it
 may produce multiple webhook deliveries — each with its own `idempotencyKey`.
 
-Example:
+Example (`balances:confirmed` payload):
 
 ```json
 {
@@ -131,6 +151,34 @@ Example:
     "txHash": "0x5b6901be92e69781a7ce401dd9a2910e1f49aa77a5bdedcd2a23c8d563d88b24",
     "address": "0x3400e577153101863f39ba41f7fd49bbea011628",
     "idempotencyKey": "d3b8cef0ad7479433783c5707da9ded4fee9b254b4638f44758a2141c49416b7:balances:confirmed",
+    "asset": {
+      "symbol": "ETH",
+      "name": "Ethereum",
+      "decimals": 18,
+      "caip19": "eip155:8453/slip44:60",
+      "amount": "4793760441409"
+    },
+    "block": {
+      "number": 46343814,
+      "hash": "0x41a4e8d444e5410f83c1ac35c838c7d8be1e3d6f32a35a04c72096adae74d095",
+      "timestamp": "2026-05-22T19:09:35Z"
+    }
+  }
+}
+```
+
+Example (`balances:finalized` payload):
+```json
+{
+  "type": "balances:finalized",
+  "organizationId": "95dfcd47-99bb-4433-9126-1524110d68e6",
+  "parentOrganizationId": "95dfcd47-99bb-4433-9126-1524110d68e6",
+  "msg": {
+    "operation": "deposit",
+    "caip2": "eip155:8453",
+    "txHash": "0x5b6901be92e69781a7ce401dd9a2910e1f49aa77a5bdedcd2a23c8d563d88b24",
+    "address": "0x3400e577153101863f39ba41f7fd49bbea011628",
+    "idempotencyKey": "d3b8cef0ad7479433783c5707da9ded4fee9b254b4638f44758a2141c49416b7:balances:finalized",
     "asset": {
       "symbol": "ETH",
       "name": "Ethereum",

--- a/snippets/shared/balance-concepts.mdx
+++ b/snippets/shared/balance-concepts.mdx
@@ -138,7 +138,7 @@ Each delivery corresponds to a single balance-change event: one address, one ope
 `withdraw`), and one asset. Because a single transaction can affect multiple addresses or assets, it
 may produce multiple webhook deliveries — each with its own `idempotencyKey`.
 
-Example (`balances:confirmed` payload):
+##### Example payload (`balances:confirmed`)
 
 ```json
 {
@@ -167,7 +167,7 @@ Example (`balances:confirmed` payload):
 }
 ```
 
-Example (`balances:finalized` payload):
+##### Example payload (`balances:finalized`)
 ```json
 {
   "type": "balances:finalized",


### PR DESCRIPTION
This PR adds documentation for the confirmation thresholds used by our `balances:finalized` webhooks in a per-network table, and also adds an example `balances:finalized` payload.