### PR TITLE
docs(stamps): clarify API key curves and fix typos in stamps page

### DIFF
--- a/api-reference/overview/stamps.mdx
+++ b/api-reference/overview/stamps.mdx
@@ -17,9 +17,9 @@ To create a valid, API key stamped request follow these steps:
    <Step>
       Create a JSON-encoded stamp:
 
-         * `publicKey`: the public key of API key, note that only P-256 keys (API_KEY_CURVE_P256) are currently supported
-         * `signature`: the signature produced by the API key
-         * `scheme`: `SIGNATURE_SCHEME_TK_API_P256`
+         * `publicKey`: the public key of the API key. Turnkey supports multiple API key curves, including `API_KEY_CURVE_P256`, `API_KEY_CURVE_SECP256K1`, and `API_KEY_CURVE_ED25519`. The `publicKey` value is the compressed (for P-256 and SECP256K1) or raw (for Ed25519) public key, hex encoded.
+         * `signature`: the signature produced by the API key over the JSON-encoded POST body, hex encoded.
+         * `scheme`: the signature scheme used to sign the request. For example, P-256 API keys use `SIGNATURE_SCHEME_TK_API_P256`. The scheme value identifies how the server should verify the signature; if you use a non-P-256 curve, refer to the API key stamper SDK for the matching scheme value.
    </Step>
    <Step>
       Base64URL encode the stamp
@@ -34,13 +34,13 @@ To create a valid, API key stamped request follow these steps:
 
 ### WebAuthn
 
-To create a valid, Webauthn authenticator stamped request follow these steps:
+To create a valid, WebAuthn authenticator stamped request follow these steps:
 <Steps>
    <Step>
-      Compute the webauthn challenge by hashing the POST body bytes (JSON encoded) with SHA256. For example, if the POST body is `{"organization_id": "1234", "type": "ACTIVITY_TYPE_CREATE_API_KEYS", "params": {"for": "example"}`, the webauthn challenge is the string `7e8b4653fc7e51dc119cea031942f4693b4742ceca4dda269b925802b38b2147`
+      Compute the WebAuthn challenge by hashing the POST body bytes (JSON encoded) with SHA256. For example, if the POST body is `{"organization_id": "1234", "type": "ACTIVITY_TYPE_CREATE_API_KEYS", "params": {"for": "example"}}`, the WebAuthn challenge is the string `7e8b4653fc7e51dc119cea031942f4693b4742ceca4dda269b925802b38b2147`
    </Step>
    <Step>
-      Include the challenge amongst WebAuthn signing options. Refer to the existing stamper implementations in the [following section](#stampers)) for examples
+      Include the challenge amongst WebAuthn signing options. Refer to the existing stamper implementations in the [following section](#stampers) for examples
 
 
       * Note that if you need to pass the challenge as bytes, you'll need to utf8-encode the challenge string (in JS, the challenge bytes will be `TextEncoder().encode("7e8b4653fc7e51dc119cea031942f4693b4742ceca4dda269b925802b38b2147")`)
@@ -51,10 +51,10 @@ To create a valid, Webauthn authenticator stamped request follow these steps:
    <Step>
       Create a JSON-encoded stamp:
 
-      * `credentialId`: the id of the webauthn authenticator
-      * `authenticatorData`: the authenticator data produced by Webauthn assertion
-      * `clientDataJson`: the client data produced by the Webauthn assertion
-      * `signature`: the signature produced by the Webauthn assertion
+      * `credentialId`: the id of the WebAuthn authenticator
+      * `authenticatorData`: the authenticator data produced by the WebAuthn assertion
+      * `clientDataJson`: the client data produced by the WebAuthn assertion
+      * `signature`: the signature produced by the WebAuthn assertion
    </Step>
 
    <Step>


### PR DESCRIPTION
## Summary

Updates `api-reference/overview/stamps.mdx` to fix outdated content and typos in the API key stamp / WebAuthn stamp documentation.

Linear: [ENG-2513 — Fix stamps docs](https://linear.app/turnkey/issue/ENG-2513/fix-stamps-docs)

## Changes

- **API key stamp `publicKey` field:** previously claimed only P-256 API keys are supported. Updated to note Turnkey supports multiple API key curves (`API_KEY_CURVE_P256`, `API_KEY_CURVE_SECP256K1`, `API_KEY_CURVE_ED25519`) and to describe the encoding of the public key value.
- **API key stamp `signature` field:** clarified that the value is hex encoded and is the signature over the JSON-encoded POST body.
- **API key stamp `scheme` field:** kept the existing P-256 example value (`SIGNATURE_SCHEME_TK_API_P256`) since the CLI output sample further down the page uses it, but reworded so it no longer reads as the only valid value. Pointed users to the API key stamper SDK for the matching scheme when using non-P-256 curves, rather than overclaiming a list of values not currently exposed in the public swagger.
- **JSON body example fix:** the example WebAuthn challenge body `{"organization_id": "1234", "type": "ACTIVITY_TYPE_CREATE_API_KEYS", "params": {"for": "example"}` was missing a closing `}`. Now valid JSON.
- **Markdown link fix:** removed stray extra `)` in `[following section](#stampers))`.
- **Casing:** normalized `Webauthn` -> `WebAuthn` in prose. Header names (`X-Stamp-Webauthn`) were intentionally left alone since the page explicitly notes header names are case-insensitive.

## Out of scope

- Generated API reference files (e.g. `api-reference/activities/*.mdx`) are not touched. Per `Makefile`, those are regenerated from `public_api.swagger.json` / `proxy_api.swagger.json` via `make gen`. Only the hand-authored stamps overview page is updated here.
- The original Slack thread linked in the Linear issue was not accessible (Slack integration not in that channel), so this PR addresses the issues called out in the Linear description and comment.

## Verification

- `git diff --check` clean.
- Manual review of rendered changes against the updated bullet list and JSON example.
- Confirmed enum names `API_KEY_CURVE_P256`, `API_KEY_CURVE_SECP256K1`, `API_KEY_CURVE_ED25519` exist in `public_api.swagger.json`.
- Confirmed `SIGNATURE_SCHEME_TK_API_P256` matches the value already shown in the CLI base64 stamp example at the bottom of the page (decoded JSON: `{"scheme":"SIGNATURE_SCHEME_TK_API_P256"}`).