### PR TITLE
change SVM input doc from base64 to hex

### DIFF
--- a/features/transaction-management/sending-sponsored-solana-transactions.mdx
+++ b/features/transaction-management/sending-sponsored-solana-transactions.mdx
@@ -59,7 +59,7 @@ if (!walletAccount) {
 await handleSendTransaction({
   transaction: {
     signWith: walletAccount.address,
-    unsignedTransaction: "<base64-serialized-unsigned-solana-tx>",
+    unsignedTransaction: "<hex-serialized-unsigned-solana-tx>",
     caip2: "solana:mainnet",
     sponsor: true,
   },

--- a/snippets/shared/send-tx-core.mdx
+++ b/snippets/shared/send-tx-core.mdx
@@ -63,7 +63,7 @@ OR (Solana):
 const sendTransactionStatusId = await client.solSendTransaction({
   transaction: {
     signWith: walletAccount.address, // Solana address
-    unsignedTransaction: "<base64-serialized-unsigned-solana-tx>",
+    unsignedTransaction: "<hex-serialized-unsigned-solana-tx>",
     caip2: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // devnet
     sponsor: true,
     // recentBlockhash: "<recent blockhash>", // optional

--- a/snippets/shared/send-tx-react.mdx
+++ b/snippets/shared/send-tx-react.mdx
@@ -60,7 +60,7 @@ if (!walletAccount) {
 await handleSendTransaction({
   transaction: {
     signWith: walletAccount.address, // Solana address
-    unsignedTransaction: "<base64-serialized-unsigned-solana-tx>",
+    unsignedTransaction: "<hex-serialized-unsigned-solana-tx>",
     caip2: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // devnet
     sponsor: true,
     // recentBlockhash: "<recent blockhash>", // optional


### PR DESCRIPTION
## Summary
Fixes Solana transaction docs to state that unsignedTransaction must be hex-encoded, not base64-encoded.