### PR TITLE
Fix mobile selector row truncating description text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1132,6 +1132,7 @@ a.nav-tabs-item[href="/welcome"][data-active="true"]::before {
     align-items: center;
     width: 100%;
     max-width: 100%;
+    height: auto;
     min-height: 54px;
     padding: 8px;
     white-space: normal;


### PR DESCRIPTION
## Summary
- Fixes the SDKs description ("TypeScript, React, React Native, and more") getting cut off on mobile
- The base `.tk-selector-row` sets `height: 40px`, but the mobile (`≤868px`) override only set `min-height: 54px` without resetting `height` to `auto`, preventing the row from growing when text wraps
- Adds `height: auto` to the mobile override so the row can expand to fit wrapped content

Follow-up to #674.

## Test plan
- [x] Run `npx mintlify dev` locally
- [x] Open welcome page in mobile viewport (~375px wide)
- [x] Verify "TypeScript, React, React Native, and more" is fully visible without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)