### PR TITLE
Clarify webhook SDK compatibility docs

### DIFF
--- a/features/webhooks/overview.mdx
+++ b/features/webhooks/overview.mdx
@@ -35,6 +35,14 @@ Create webhook endpoints from a server-side client using an API key, or from any
 
 SDK methods accept the intent parameters directly. The SDK adds the activity envelope fields (`type`, `timestampMs`, `organizationId`, and `parameters`) before signing and submitting the request. Use the raw envelope shape only when calling the HTTP API directly.
 
+<Note>
+Server-side SDK path: `createWebhookEndpoint` is available in `@turnkey/sdk-server@6.1.0+`. This is the recommended SDK for server-side/API-key automation.
+
+Browser SDK path: `createWebhookEndpoint` is also available in `@turnkey/sdk-browser@6.1.0+`. Browser clients may use it only when they can submit signed activities for the organization.
+
+Raw HTTP and CLI submission remain supported for direct activity submission. SDK methods accept intent parameters directly; raw HTTP uses the activity envelope shape.
+</Note>
+
 ### Activity updates
 
 ```ts
@@ -236,9 +244,9 @@ Read operations, such as listing webhook endpoints, use standard authenticated q
 
 | Symptom | What to check |
 |---|---|
-| `createWebhookEndpoint` is unavailable in your SDK | Upgrade to a webhooks-capable SDK release. The minimum SDK version will be listed in the SDK changelog once published. |
-| `PermissionDenied` on create/update/delete | Confirm the user has an allow policy for the webhook activity type, and confirm balance webhooks are being managed from the billing organization. |
-| Empty or unclear endpoint names | Set `parameters.name` to a non-empty, human-readable name. |
-| Subscription shape errors | Pass event types inside `parameters.subscriptions[]`, not as top-level `eventTypes`. |
+| `createWebhookEndpoint` is unavailable in your SDK | Upgrade to `@turnkey/sdk-server@6.1.0+` or `@turnkey/sdk-browser@6.1.0+`. Use `@turnkey/sdk-server` for server-side/API-key automation. Use `@turnkey/sdk-browser` only when the browser client can submit signed activities for the organization. |
+| `PermissionDenied` on create/update/delete | Confirm the user has an allow policy for the webhook activity type. For balance or transaction-status webhooks, also confirm the endpoint is being managed from the billing organization. |
+| Subscription shape errors | Pass event types inside `subscriptions[]`, not as top-level `eventTypes`. For raw HTTP activity submission, put `subscriptions[]` inside `parameters`. |
+| Empty endpoint names | Set a non-empty, human-readable `name`. For raw HTTP activity submission, set `parameters.name`. |
 | Invalid webhook URL errors | Use an HTTPS URL that resolves to a public destination. Localhost, private IPs, link-local addresses, metadata endpoints, and URLs with user info are rejected. |
-| Signature verification fails | See [Verify webhook signatures](/features/webhooks/verify-signatures). Common causes: re-serialized JSON body, clock skew, or missing signing key. |
+| Signature verification fails | See [Verify webhook signatures](/features/webhooks/verify-signatures). Common causes: not using the exact raw request body, clock skew, or a missing/stale JWKS key. Cache JWKS according to `Cache-Control` and refetch when the signature `kid` is unknown. |

--- a/features/webhooks/overview.mdx
+++ b/features/webhooks/overview.mdx
@@ -36,9 +36,9 @@ Create webhook endpoints from a server-side client using an API key, or from any
 SDK methods accept the intent parameters directly. The SDK adds the activity envelope fields (`type`, `timestampMs`, `organizationId`, and `parameters`) before signing and submitting the request. Use the raw envelope shape only when calling the HTTP API directly.
 
 <Note>
-Server-side SDK path: `createWebhookEndpoint` is available in `@turnkey/sdk-server@6.1.0+`. This is the recommended SDK for server-side/API-key automation.
+For server-side/API-key automation, use `@turnkey/sdk-server@6.1.0+`; it includes `createWebhookEndpoint`.
 
-Browser SDK path: `createWebhookEndpoint` is also available in `@turnkey/sdk-browser@6.1.0+`. Browser clients may use it only when they can submit signed activities for the organization.
+For browser clients that can submit signed activities for the organization, `@turnkey/sdk-browser@6.1.0+` also includes `createWebhookEndpoint`.
 
 Raw HTTP and CLI submission remain supported for direct activity submission. SDK methods accept intent parameters directly; raw HTTP uses the activity envelope shape.
 </Note>


### PR DESCRIPTION
## Summary
- Focused ENG-4126 follow-up for the currently deployed `/features/webhooks/*` pages.
- Adds SDK compatibility guidance for `createWebhookEndpoint` near endpoint creation on `/features/webhooks/overview`.
- Replaces placeholder troubleshooting with exact SDK versions and differentiated setup/signature failure guidance.

## Scope
- Intentionally does not include the larger #689 Webhooks V2 restructure.
- Does not move pages, add the #689 reference-section restructure, or add the experimental webhook.site generator.

## SDK source of truth
- SDK versions were verified against `tkhq/sdk` `origin/main` commit `764965f54`.
- `@turnkey/sdk-server@6.1.0+` and `@turnkey/sdk-browser@6.1.0+` include `createWebhookEndpoint`.
- `@turnkey/crypto@2.10.0+` exports `verifyTurnkeyWebhookSignature`.

## Validation
- `jq . docs.json`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `PATH=/Users/taylordawson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx mintlify validate`

Note: `npx mintlify validate` fails under the default local Node 25.6.1 because Mintlify rejects Node 25+. It passed when run with the bundled Node 24.14.0 runtime.