### PR TITLE
fix navigation, knowingly reintroduce warning

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -876,9 +876,9 @@
                   "generated-docs/core/turnkey-client-verify-otp"
                 ]
               },
-              "solutions/embedded-wallets/integration-guide/flutter/index",
-              "solutions/embedded-wallets/integration-guide/swift/overview",
-              "solutions/embedded-wallets/integration-guide/kotlin/overview",
+              "solutions/embedded-wallets/integration-guide/flutter",
+              "solutions/embedded-wallets/integration-guide/swift",
+              "solutions/embedded-wallets/integration-guide/kotlin",
               "solutions/company-wallets/integration-guide/javascript-server",
               "solutions/company-wallets/integration-guide/golang",
               "solutions/company-wallets/integration-guide/ruby",


### PR DESCRIPTION
restore descriptive titles to SDK reference
<img width="353" height="370" alt="image" src="https://github.com/user-attachments/assets/c1651fdc-7bc9-4566-9909-65c565cc5e0e" />
to
<img width="344" height="378" alt="image" src="https://github.com/user-attachments/assets/b1e8a367-dd2c-4323-aea2-2e2ba86c09ac" />
but doing so reintroduces a non-essential warning, originally reverted in #683 
```
$ mintlify dev                                                 
warning - "solutions/embedded-wallets/integration-guide/flutter" is referenced in the docs.json navigation but the file does not exist.
warning - "solutions/embedded-wallets/integration-guide/swift" is referenced in the docs.json navigation but the file does not exist.
warning - "solutions/embedded-wallets/integration-guide/kotlin" is referenced in the docs.json navigation but the file does not exist.

✓ preview ready