### PR TITLE
Point webhook browser docs to core SDK

### DIFF
--- a/features/webhooks/overview.mdx
+++ b/features/webhooks/overview.mdx
@@ -31,14 +31,14 @@ For further information on balances, including supported chains and assets, see 
 
 ## Create an endpoint
 
-Create webhook endpoints from a server-side client using an API key, or from any Turnkey client that can submit signed activities for your organization. The endpoint URL must be HTTPS and must resolve to a public destination.
+Create webhook endpoints from a server-side client using an API key. The endpoint URL must be HTTPS and must resolve to a public destination.
 
 SDK methods accept the intent parameters directly. The SDK adds the activity envelope fields (`type`, `timestampMs`, `organizationId`, and `parameters`) before signing and submitting the request. Use the raw envelope shape only when calling the HTTP API directly.
 
 <Note>
 For server-side/API-key automation, use `@turnkey/sdk-server@6.1.0+`; it includes `createWebhookEndpoint`.
 
-For browser clients that can submit signed activities for the organization, `@turnkey/sdk-browser@6.1.0+` also includes `createWebhookEndpoint`.
+For client-side admin flows, `@turnkey/core` can also submit webhook endpoint activities through `client.httpClient.createWebhookEndpoint(...)`, provided the authenticated session is authorized to submit signed activities for the organization.
 
 Raw HTTP and CLI submission remain supported for direct activity submission. SDK methods accept intent parameters directly; raw HTTP uses the activity envelope shape.
 </Note>
@@ -244,7 +244,7 @@ Read operations, such as listing webhook endpoints, use standard authenticated q
 
 | Symptom | What to check |
 |---|---|
-| `createWebhookEndpoint` is unavailable in your SDK | Upgrade to `@turnkey/sdk-server@6.1.0+` or `@turnkey/sdk-browser@6.1.0+`. Use `@turnkey/sdk-server` for server-side/API-key automation. Use `@turnkey/sdk-browser` only when the browser client can submit signed activities for the organization. |
+| `createWebhookEndpoint` is unavailable in your SDK | Use `@turnkey/sdk-server@6.1.0+` for server-side/API-key automation. Use `@turnkey/core` for browser/client-side admin flows. |
 | `PermissionDenied` on create/update/delete | Confirm the user has an allow policy for the webhook activity type. For balance or transaction-status webhooks, also confirm the endpoint is being managed from the billing organization. |
 | Subscription shape errors | Pass event types inside `subscriptions[]`, not as top-level `eventTypes`. For raw HTTP activity submission, put `subscriptions[]` inside `parameters`. |
 | Empty endpoint names | Set a non-empty, human-readable `name`. For raw HTTP activity submission, set `parameters.name`. |


### PR DESCRIPTION
## Summary
- Keep server-side/API-key automation as the main guidance for creating webhook endpoints.
- Keep client-side admin flows as a short note using @turnkey/core via client.httpClient.createWebhookEndpoint(...), only with an authorized authenticated session.
- Remove the standalone browser-side @turnkey/core code sample.

## Checks
- PASS: git diff --check origin/main...HEAD
- PASS: signed commit verified with git log --show-signature -1
- FAIL (pre-existing): npx mintlify validate under Node 24 exits on docs.json warnings for missing Flutter, Swift, and Kotlin nav pages
- FAIL (pre-existing): npx mintlify broken-links reports unrelated links in features/authentication/social-logins.mdx, scripts/openapi-gen/openapi-gen-plan.md, and solutions/embedded-wallets/integration-guide/overview.mdx