### PR TITLE
fix(docs): fix broken external links (404) across multiple pages

### DIFF
--- a/features/networks/bitcoin.mdx
+++ b/features/networks/bitcoin.mdx
@@ -19,7 +19,7 @@ You can derive Bitcoin addresses when creating a Turnkey wallet or private key. 
 * P2SH (Pay-To-Script-Hash)
 * P2WPKH (Pay-to-Witness-Public-Key-Hash) -- [segwit-enabled](https://learnmeabitcoin.com/technical/upgrades/segregated-witness/)
 * P2WSH (Pay-to-Witness-Script-Hash) -- [segwit-enabled](https://learnmeabitcoin.com/technical/upgrades/segregated-witness/)
-* P2TR (Pay-to-Taproot) -- [taproot-enabled](https://cointelegraph.com/learn/a-beginners-guide-to-the-bitcoin-taproot-upgrade)
+* P2TR (Pay-to-Taproot) -- [taproot-enabled](https://learnmeabitcoin.com/technical/upgrades/taproot/)
 
 Bitcoin addresses change depending on the network you're using (more precisely, their prefix!). When you derive an address the network will be part of the address format. We support the following networks:
 

--- a/features/networks/solana.mdx
+++ b/features/networks/solana.mdx
@@ -9,7 +9,7 @@ Turnkey supports Solana address derivation with `ADDRESS_TYPE_SOLANA`. Solana ad
 
 ## Transaction construction and signing
 
-To construct and sign a Solana transaction we offer a `@turnkey/solana` NPM package. It offers a `TurnkeySigner` which integrates our remote signer with the official Solana [`web3js`](https://solana-labs.github.io/solana-web3.js/) library.
+To construct and sign a Solana transaction we offer a `@turnkey/solana` NPM package. It offers a `TurnkeySigner` which integrates our remote signer with the official Solana [`web3js`](https://github.com/solana-foundation/solana-web3.js) library.
 
 ## Transaction management and gas sponsorship
 

--- a/features/wallets/aa-wallets.mdx
+++ b/features/wallets/aa-wallets.mdx
@@ -17,7 +17,7 @@ Visit [the Alchemy Account Kit documentation](https://www.alchemy.com/docs/walle
 
 By combining Turnkey with ZeroDev you can create AA wallets with powerful functionalities such as sponsoring gas, batching transactions, and more.
 
-Visit [the ZeroDev documentation](https://docs.zerodev.app/sdk/signers/turnkey) for more information.
+Visit [the ZeroDev documentation](https://docs.zerodev.app/smart-accounts/authentication/turnkey) for more information.
 
 ## Biconomy smart accounts
 

--- a/reference/migration-guide.mdx
+++ b/reference/migration-guide.mdx
@@ -28,7 +28,7 @@ This can be done **"just in time,"** creating the Turnkey user information (like
 
 This export typically takes the form of an export modal which displays the private key or seed phrase in plaintext to the user. The specifics depend on your provider, but popular choices typically have methods designed for the user to copy their key/seed to clipboard.
 * [Privy - `exportWallet`](https://docs.privy.io/wallets/wallets/export#react) (React)
-* [Dynamic - `exportPrivateKey`](https://www.dynamic.xyz/docs/global-wallets/export) (React)
+* [Dynamic - `exportPrivateKey`](https://www.dynamic.xyz/docs/react/wallets/embedded-wallets/mpc/import-export#exporting-wallet-keys) (React)
 * [Fireblocks - `full key takeover`](https://ncw-developers.fireblocks.com/docs/full-key-takeover)
 * Other - some services like Para or web3auth lack embeddable key export functionality and may require users to export keys using the service dashboard
 

--- a/solutions/cookbooks/jupiter.mdx
+++ b/solutions/cookbooks/jupiter.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Jupiter integration"
 
 ## Overview
 
-[Jupiter](https://station.jup.ag/) is Solana’s leading liquidity aggregator, enabling users to execute optimal token swaps across multiple DEXs through its [Ultra API](https://station.jup.ag/docs/apis/ultra-api).
+[Jupiter](https://station.jup.ag/) is Solana’s leading liquidity aggregator, enabling users to execute optimal token swaps across multiple DEXs through its [Swap API](https://developers.jup.ag/docs/swap).
 
 This cookbook shows how to integrate **Turnkey** wallets with **Jupiter Ultra Swap** using the [`with-jupiter`](https://github.com/tkhq/sdk/tree/main/examples/defi/with-jupiter) example.  
 You’ll learn how to authenticate with Turnkey, load a wallet, and use it to create, sign, and send Solana swap transactions directly through the Jupiter API.

--- a/solutions/cookbooks/tron-gasless-transactions.mdx
+++ b/solutions/cookbooks/tron-gasless-transactions.mdx
@@ -27,7 +27,7 @@ the high standard for security, flexibility, and scalability.
      > **TIP:** This can be a wallet contained within your parent organization
 
    - Initialize the staking activity by calling the
-     [freezeBalanceV2](https://developers.tron.network/reference/freezebalancev2-1) function
+     [freezeBalanceV2](https://developers.tron.network/reference/freezebalancev2) function
 
      > Refer to Tron Network’s [official documentation](https://developers.tron.network/docs/) for
      > further information
@@ -36,7 +36,7 @@ the high standard for security, flexibility, and scalability.
    - After you’ve initialized the staking operation using freezeBalanceV2 (Step 1) you’re now able
      to delegate the resources to end-user wallets
    - From the staking wallet, make a call to the Tron network using
-     [DelegateResource](https://developers.tron.network/reference/delegateresource-1) function
+     [DelegateResource](https://developers.tron.network/reference/delegateresource) function
      - `owner_address`: Wallet that is staking TRX (Step 1A)
      - `receiver_address`: Wallet controlled by the end-user
      - `resource`: The resource you’re delegating, bandwidth
@@ -48,7 +48,7 @@ the high standard for security, flexibility, and scalability.
 ### **Leveraging delegateResource smart contract function**
 
 As shown above, we are leveraging the existing
-[DelegateResource](https://developers.tron.network/reference/delegateresource-1) call to delegate
+[DelegateResource](https://developers.tron.network/reference/delegateresource) call to delegate
 bandwidth or energy resources to other accounts. Note that this operation requires you to have
 Tron’s native network token TRX staked in order to fund end-user’s transactions.
 

--- a/solutions/embedded-wallets/integration-guide/react/advanced-backend-authentication.mdx
+++ b/solutions/embedded-wallets/integration-guide/react/advanced-backend-authentication.mdx
@@ -121,7 +121,7 @@ export async function createSubOrg(
 }
 ```
 
-_Code snippet taken from our Swift example [here](https://github.com/tkhq/swift-sdk/blob/main/Examples/swift-demo-wallet/example-server/src/handler.ts). You can use this as reference for a full Javascript server implementation._
+_Code snippet taken from our Swift example [here](https://github.com/tkhq/swift-sdk/blob/main/Examples/with-backend/example-server/src/handler.ts). You can use this as reference for a full Javascript server implementation._
 
 Turnkey also offers [Rust](https://github.com/tkhq/rust-sdk) and [Go](https://github.com/tkhq/go-sdk) SDKs that can be used to implement the backend endpoints. You can also use any other backend language you prefer as long as it can make HTTP requests to the Turnkey API.
 

--- a/solutions/embedded-wallets/integration-guide/swift/advanced-backend-authentication.mdx
+++ b/solutions/embedded-wallets/integration-guide/swift/advanced-backend-authentication.mdx
@@ -55,7 +55,7 @@ Notes:
 - Passkey and external wallet login happen on-device via [`login-with-a-stamp`](/api-reference/activities/login-with-a-stamp). Signup still requires `createSubOrganization` on your backend.
 - You may apply custom validation, logging, and rate limiting in your server.
 
-For a complete server example, see the Swift demo wallet's example server in the Swift SDK repo: [swift-sdk/Examples/legacy-swift-demo-wallet/example-server](https://github.com/tkhq/swift-sdk/tree/main/Examples/legacy-swift-demo-wallet/example-server).
+For a complete server example, see the Swift demo wallet's example server in the Swift SDK repo: [swift-sdk/Examples/with-backend/example-server](https://github.com/tkhq/swift-sdk/tree/main/Examples/with-backend/example-server).
 
 ### Minimal Node/Express signup endpoint
 

--- a/solutions/embedded-wallets/integration-guide/typescript/advanced-backend-authentication.mdx
+++ b/solutions/embedded-wallets/integration-guide/typescript/advanced-backend-authentication.mdx
@@ -22,7 +22,7 @@ You will need to implement various authentication endpoints on your backend serv
 - [`otpLogin`](/api-reference/activities/login-with-otp): Handle OTP login flow (you can also combine this with `verifyOtp` to make a single endpoint).
 - [`oauthLogin`](/api-reference/activities/login-with-oauth): Handle OAuth login flow.
 
-**Note:** **passkey** and **wallet** login will occur in the frontend using [`stampLogin`](/api-reference/activities/login-with-a-stamp), so you do not need to implement any additional endpoints for those. Signup however will still require the `createSubOrganization` endpoint to create a new sub-organization for the user. See the [implementation in `@turnkey/core`](https://github.com/tkhq/sdk/blob/amir/sdk-js/packages/core/src/__clients__/core.ts) for more details on how to implement `loginWithPasskey` and `loginWithWallet` using the `stampLogin` activity.
+**Note:** **passkey** and **wallet** login will occur in the frontend using [`stampLogin`](/api-reference/activities/login-with-a-stamp), so you do not need to implement any additional endpoints for those. Signup however will still require the `createSubOrganization` endpoint to create a new sub-organization for the user. See the [implementation in `@turnkey/core`](https://github.com/tkhq/sdk/blob/main/packages/core/src/__clients__/core.ts) for more details on how to implement `loginWithPasskey` and `loginWithWallet` using the `stampLogin` activity.
 
 Here's an example of how you might implement the `createSubOrganization` endpoint in Node.js using Express and the [`@turnkey/sdk-server`](https://www.npmjs.com/package/@turnkey/sdk-server) package:
 
@@ -96,7 +96,7 @@ export async function createSubOrg(
 }
 ```
 
-_Code snippet taken from our Swift example [here](https://github.com/tkhq/swift-sdk/blob/main/Examples/swift-demo-wallet/example-server/src/handler.ts). You can use this as reference for a full Javascript server implementation._
+_Code snippet taken from our Swift example [here](https://github.com/tkhq/swift-sdk/blob/main/Examples/with-backend/example-server/src/handler.ts). You can use this as reference for a full Javascript server implementation._
 
 Turnkey also offers [Rust](https://github.com/tkhq/rust-sdk) and [Go](https://github.com/tkhq/go-sdk) SDKs that can be used to implement the backend endpoints. You can also use any other backend language you prefer as long as it can make HTTP requests to the Turnkey API.
 


### PR DESCRIPTION
## Problem
Multiple documentation pages contain broken external links returning 404:
- `solutions/embedded-wallets/integration-guide/swift/advanced-backend-authentication.mdx`
- `solutions/embedded-wallets/integration-guide/react/advanced-backend-authentication.mdx`
- `solutions/embedded-wallets/integration-guide/typescript/advanced-backend-authentication.mdx`
- `solutions/cookbooks/tron-gasless-transactions.mdx`
- `features/networks/solana.mdx`
- `features/networks/bitcoin.mdx`
- `features/wallets/aa-wallets.mdx`
- `reference/migration-guide.mdx`
- `solutions/cookbooks/jupiter.mdx`

## Root Cause
- `legacy-swift-demo-wallet` example folder was renamed to `with-backend` in swift-sdk repo
- `amir/sdk-js` branch was merged into `main` in sdk repo
- Tron API reference URLs had a trailing `-1` suffix that no longer resolves
- Solana web3.js docs moved from `solana-labs.github.io` to `solana-foundation` on GitHub
- ZeroDev restructured their docs from `/sdk/signers/` to `/smart-accounts/authentication/`
- Dynamic restructured their docs from `/global-wallets/` to `/react/wallets/embedded-wallets/`
- Jupiter deprecated Ultra API and replaced it with Swap API

## Fix

**`swift/advanced-backend-authentication.mdx`**
```diff
- [swift-sdk/Examples/legacy-swift-demo-wallet/example-server](https://github.com/tkhq/swift-sdk/tree/main/Examples/legacy-swift-demo-wallet/example-server)
+ [swift-sdk/Examples/with-backend/example-server](https://github.com/tkhq/swift-sdk/tree/main/Examples/with-backend/example-server)
```

**`react/advanced-backend-authentication.mdx`**
```diff
- [our Swift example](https://github.com/tkhq/swift-sdk/blob/main/Examples/swift-demo-wallet/example-server/src/handler.ts)
+ [our Swift example](https://github.com/tkhq/swift-sdk/blob/main/Examples/with-backend/example-server/src/handler.ts)
```

**`typescript/advanced-backend-authentication.mdx`**
```diff
- https://github.com/tkhq/sdk/blob/amir/sdk-js/packages/core/src/__clients__/core.ts
+ https://github.com/tkhq/sdk/blob/main/packages/core/src/__clients__/core.ts

- https://github.com/tkhq/swift-sdk/blob/main/Examples/swift-demo-wallet/example-server/src/handler.ts
+ https://github.com/tkhq/swift-sdk/blob/main/Examples/with-backend/example-server/src/handler.ts
```

**`tron-gasless-transactions.mdx`**
```diff
- [freezeBalanceV2](https://developers.tron.network/reference/freezebalancev2-1)
+ [freezeBalanceV2](https://developers.tron.network/reference/freezebalancev2)

- [DelegateResource](https://developers.tron.network/reference/delegateresource-1)
+ [DelegateResource](https://developers.tron.network/reference/delegateresource)
```

**`solana.mdx`**
```diff
- [`web3js`](https://solana-labs.github.io/solana-web3.js/)
+ [`web3js`](https://github.com/solana-foundation/solana-web3.js)
```

**`bitcoin.mdx`**
```diff
- [taproot-enabled](https://cointelegraph.com/learn/a-beginners-guide-to-the-bitcoin-taproot-upgrade)
+ [taproot-enabled](https://learnmeabitcoin.com/technical/upgrades/taproot/)
```

**`aa-wallets.mdx`**
```diff
- [the ZeroDev documentation](https://docs.zerodev.app/sdk/signers/turnkey)
+ [the ZeroDev documentation](https://docs.zerodev.app/smart-accounts/authentication/turnkey)
```

**`migration-guide.mdx`**
```diff
- [Dynamic - `exportPrivateKey`](https://www.dynamic.xyz/docs/global-wallets/export)
+ [Dynamic - `exportPrivateKey`](https://www.dynamic.xyz/docs/react/wallets/embedded-wallets/mpc/import-export#exporting-wallet-keys)
```

**`jupiter.mdx`**
```diff
- [Ultra API](https://station.jup.ag/docs/apis/ultra-api)
+ [Swap API](https://developers.jup.ag/docs/swap)
```

## Verification
All target URLs confirmed working at time of PR submission.