### PR TITLE
fix(docs): fix broken internal links (404) across multiple pages

### DIFF
--- a/features/authentication/overview.mdx
+++ b/features/authentication/overview.mdx
@@ -19,7 +19,7 @@ In addition to the API secret, you can also configure **authorization policies**
 
 For backend implementation details, see our [Backend Setup](/features/authentication/backend-setup) guide.
 
-**API Reference**: [Create API Keys](/api-reference/api-keys/create-api-keys), [Get API Keys](/api-reference/api-keys/get-api-key)
+**API Reference**: [Create API Keys](/api-reference/activities/create-api-keys), [Get API Keys](/api-reference/queries/get-api-keys)
 
 ## User authentication
 

--- a/features/wallets.mdx
+++ b/features/wallets.mdx
@@ -111,7 +111,7 @@ Contact us at [hello@turnkey.com](mailto:hello@turnkey.com).
 
 ## Delete wallets
 
-To delete wallets you can call the [delete wallets activity](/api-reference/wallets/delete-wallets). Before deleting a wallet it must have been exported to prevent loss of funds, or you can pass in the `deleteWithoutExport` parameter with the value `true` to override this. The `deleteWithoutExport` parameter, if not passed in, is default `false`. Note that this activity must be initiated by the wallet owner.
+To delete wallets you can call the [delete wallets activity](/api-reference/activities/delete-wallets). Before deleting a wallet it must have been exported to prevent loss of funds, or you can pass in the `deleteWithoutExport` parameter with the value `true` to override this. The `deleteWithoutExport` parameter, if not passed in, is default `false`. Note that this activity must be initiated by the wallet owner.
 
 ## Private keys
 
@@ -131,4 +131,4 @@ Importing on Turnkey enables you or your end users to import a Wallet or Private
 
 ## Delete keys
 
-To delete private keys you can call the [delete private keys activity](/api-reference/private-keys/delete-private-keys). Before deleting a private key it must have been exported to prevent loss of funds, or you can pass in the `deleteWithoutExport` parameter with the value `true` to override this. The `deleteWithoutExport` parameter, if not passed in, is default `false`. Note that this activity must be initiated by the private key owner.
+To delete private keys you can call the [delete private keys activity](/api-reference/activities/delete-private-keys). Before deleting a private key it must have been exported to prevent loss of funds, or you can pass in the `deleteWithoutExport` parameter with the value `true` to override this. The `deleteWithoutExport` parameter, if not passed in, is default `false`. Note that this activity must be initiated by the private key owner.

--- a/get-started/backup-recovery.mdx
+++ b/get-started/backup-recovery.mdx
@@ -3,7 +3,7 @@ title: "Backup and recovery"
 description: "In line with responsible practices, backup and recovery of Turnkey accounts and/or wallets is an important consideration when designing any production system. The specific mechanisms (such as [wallet exports](/features/wallets/export-wallets)) are outlined in greater detail elsewhere - the purpose of this document is to inform and guide how to use the mechanisms available."
 ---
 
-It is Turnkey's approach that the safest place for key material is within the hardened [secure enclaves](security/secure-enclaves), and within these enclaves alone. Our model guides using authenticators (or combinations thereof) of increasing sophistication, relating to the importance or consequences of a given action. For example, a full recovery of an organization may require multiple break-glass hardware authenticators, where a routine low-stakes action might only rely on an API key.
+It is Turnkey's approach that the safest place for key material is within the hardened [secure enclaves](/security/secure-enclaves), and within these enclaves alone. Our model guides using authenticators (or combinations thereof) of increasing sophistication, relating to the importance or consequences of a given action. For example, a full recovery of an organization may require multiple break-glass hardware authenticators, where a routine low-stakes action might only rely on an API key.
 
 The below options all involve some combination of authentication methods and policies. Both of these can be difficult to change later, so consider configuring your backup and recovery methods as early as possible.
 

--- a/reference/faq.mdx
+++ b/reference/faq.mdx
@@ -95,21 +95,21 @@ title: "FAQ"
 
 <AccordionGroup>
   <Accordion title="Does Turnkey support Ethereum (EVM)?">
-    Yes! See [Ethereum (EVM) support on Turnkey](networks/ethereum) for more information and concrete examples.
+    Yes! See [Ethereum (EVM) support on Turnkey](/features/networks/ethereum) for more information and concrete examples.
   </Accordion>
   <Accordion title="Does Turnkey support Solana (SVM)?">
-    Yes! See [Solana (SVM) support on Turnkey](networks/solana) for more information and concrete examples.
+    Yes! See [Solana (SVM) support on Turnkey](/features/networks/solana) for more information and concrete examples.
   </Accordion>
   <Accordion title="Does Turnkey support Bitcoin?">
-    Yes! See [Bitcoin support on Turnkey](networks/bitcoin) for more information and concrete examples.
+    Yes! See [Bitcoin support on Turnkey](/features/networks/bitcoin) for more information and concrete examples.
   </Accordion>
   <Accordion title="Which cryptographic curves do you support?">
     Turnkey currently supports SECP256k1, Ed25519, and P256.
   </Accordion>
   <Accordion title="Which ecosystems and chains do you support?">
-    Turnkey's primitive for private keys and wallet is the **cryptographic curve** rather than specific cryptocurrencies. Our approach to supporting assets is tiered, see [this page](networks/overview) for more information.
+    Turnkey's primitive for private keys and wallet is the **cryptographic curve** rather than specific cryptocurrencies. Our approach to supporting assets is tiered, see [this page](/features/networks/overview) for more information.
 
-    We have deeper support for [Ethereum](networks/ethereum), [Solana](networks/solana), and [Bitcoin](networks/bitcoin).
+    We have deeper support for [Ethereum](/features/networks/ethereum), [Solana](/features/networks/solana), and [Bitcoin](/features/networks/bitcoin).
 
     If there are specific ecosystems or chains you'd like to see us offer deeper support for, please let us know by contacting us at [hello@turnkey.com](mailto:hello@turnkey.com), on [X](https://x.com/turnkeyhq/), or [on Slack](https://join.slack.com/t/clubturnkey/shared_invite/zt-3aemp2g38-zIh4V~3vNpbX5PsSmkKxcQ).
   </Accordion>

--- a/solutions/key-management/encryption-key-storage.mdx
+++ b/solutions/key-management/encryption-key-storage.mdx
@@ -43,7 +43,7 @@ A common pattern for applications: encrypt recovery bundles, store them in your 
 
 <Steps>
   <Step title="Create encryption keypair">
-    Generate a P-256 keypair in Turnkey using [createPrivateKeys](/api-reference/private-keys/create-private-keys). The private key is stored in Turnkey's [secure enclave](/security/secure-enclaves) and never exposed.
+    Generate a P-256 keypair in Turnkey using [createPrivateKeys](/api-reference/activities/create-private-keys). The private key is stored in Turnkey's [secure enclave](/security/secure-enclaves) and never exposed.
 
     ```typescript
     const { privateKeys } = await turnkey.apiClient().createPrivateKeys({
@@ -80,7 +80,7 @@ A common pattern for applications: encrypt recovery bundles, store them in your 
   </Step>
 
   <Step title="Authenticate and export decryption key">
-    Authenticate the user through your normal auth flow, then request the encryption private key from Turnkey using [exportPrivateKey](/api-reference/private-keys/export-private-key):
+    Authenticate the user through your normal auth flow, then request the encryption private key from Turnkey using [exportPrivateKey](/api-reference/activities/export-private-key):
 
     ```typescript
     const targetKeyPair = generateP256KeyPair();


### PR DESCRIPTION
## Problem
Multiple documentation pages contain broken internal links returning 404:
- `features/authentication/overview.mdx`
- `features/wallets.mdx`
- `reference/faq.mdx`
- `solutions/key-management/encryption-key-storage.mdx`
- `get-started/backup-recovery.mdx`

## Root Cause
- API reference URLs were restructured: `/api-reference/` paths moved under `/api-reference/activities/` and `/api-reference/queries/`
- Network pages moved from root `networks/` to `features/networks/`
- Some internal links were missing a leading slash, causing relative path resolution errors

## Fix

**`features/authentication/overview.mdx`**
```diff
- [Create API Keys](/api-reference/api-keys/create-api-keys), [Get API Keys](/api-reference/api-keys/get-api-key)
+ [Create API Keys](/api-reference/activities/create-api-keys), [Get API Keys](/api-reference/queries/get-api-keys)
```

**`features/wallets.mdx`**
```diff
- [delete wallets activity](/api-reference/wallets/delete-wallets)
+ [delete wallets activity](/api-reference/activities/delete-wallets)
- [delete private keys activity](/api-reference/private-keys/delete-private-keys)
+ [delete private keys activity](/api-reference/activities/delete-private-keys)
```

**`reference/faq.mdx`**
```diff
- [Ethereum (EVM) support on Turnkey](networks/ethereum)
+ [Ethereum (EVM) support on Turnkey](/features/networks/ethereum)
- [Solana (SVM) support on Turnkey](networks/solana)
+ [Solana (SVM) support on Turnkey](/features/networks/solana)
- [Bitcoin support on Turnkey](networks/bitcoin)
+ [Bitcoin support on Turnkey](/features/networks/bitcoin)
- [this page](networks/overview)
+ [this page](/features/networks/overview)
- [Ethereum](networks/ethereum), [Solana](networks/solana), and [Bitcoin](networks/bitcoin)
+ [Ethereum](/features/networks/ethereum), [Solana](/features/networks/solana), and [Bitcoin](/features/networks/bitcoin)
```

**`solutions/key-management/encryption-key-storage.mdx`**
```diff
- [createPrivateKeys](/api-reference/private-keys/create-private-keys)
+ [createPrivateKeys](/api-reference/activities/create-private-keys)
- [exportPrivateKey](/api-reference/private-keys/export-private-key)
+ [exportPrivateKey](/api-reference/activities/export-private-key)
```

**`get-started/backup-recovery.mdx`**
```diff
- [secure enclaves](security/secure-enclaves)
+ [secure enclaves](/security/secure-enclaves)
```

## Verification
All target URLs confirmed working at time of PR submission.