### PR TITLE
Add Robinhood Chain to supported EVM chains

### DIFF
--- a/features/networks/ethereum.mdx
+++ b/features/networks/ethereum.mdx
@@ -294,6 +294,7 @@ Turnkey supports the EVM chains below for address derivation and signing arbitra
 - Palm
 - Polygon
 - Redstone
+- Robinhood Chain
 - Scroll
 - zkSync
 - Zora


### PR DESCRIPTION
## Summary
- Adds Robinhood Chain (Arbitrum Orbit L2) to the supported EVM chains list on the Ethereum networks page

## Test plan
- [ ] Verify Robinhood Chain appears alphabetically between Redstone and Scroll in the EVM chains list
- [ ] Confirm no other pages need updating (gas sponsorship lists are chain-specific and not applicable here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)