### PR TITLE
docs(verifiable-cloud): note HTTP-only public ingress restriction

### DIFF
--- a/features/verifiable-cloud/overview.mdx
+++ b/features/verifiable-cloud/overview.mdx
@@ -87,9 +87,9 @@ Once the deployment is submitted and approved, our infrastructure deploys and ma
 
 ## Networking and ingress
 
-Each deployment is exposed on a dedicated `app-<APP_UUID>.turnkey.cloud` subdomain, with traffic load-balanced across all replicas. You specify the port that external requests are forwarded to (`publicIngressPort`), along with a separate port and type for the health checks Turnkey's infrastructure performs.
+Each deployment is exposed on a dedicated `app-<APP_UUID>.turnkey.cloud` subdomain, with traffic load-balanced across all replicas. When configuring a deployment, you specify the port that external requests are forwarded to (`publicIngressPort`), along with a separate port and type for the health checks Turnkey's infrastructure performs.
 
-Only HTTP applications can receive public ingress right now. If your app serves a non-HTTP protocol (for example, gRPC), it cannot yet be exposed on a public `turnkey.cloud` subdomain.
+Only HTTP/1 applications can receive public ingress right now. HTTP/2 (including gRPC) is not yet supported, so those apps cannot yet be exposed on a public `turnkey.cloud` subdomain.
 
 ## Manifests
 

--- a/features/verifiable-cloud/overview.mdx
+++ b/features/verifiable-cloud/overview.mdx
@@ -85,6 +85,12 @@ Once the deployment is submitted and approved, our infrastructure deploys and ma
 | Ingress     | Load-balanced across all replicas |
 | Sub-domain  | Automated (`<UUID>.turnkey.cloud`) |
 
+## Networking and ingress
+
+Each deployment is exposed on a dedicated `app-<APP_UUID>.turnkey.cloud` subdomain, with traffic load-balanced across all replicas. You specify the port that external requests are forwarded to (`publicIngressPort`), along with a separate port and type for the health checks Turnkey's infrastructure performs.
+
+Only HTTP applications can receive public ingress right now. If your app serves a non-HTTP protocol (for example, gRPC), it cannot yet be exposed on a public `turnkey.cloud` subdomain.
+
 ## Manifests
 
 Each TVC deployment is ultimately specified with a QOS manifest. The information you provide to TVC APIs (expected digest, executable arguments, and so on) is used to create a new QOS Manifest document. See [`Manifest`](https://github.com/tkhq/qos/blob/d69bcd348073ed7322c0d0423a35b7ab56831de8/src/qos_core/src/protocol/services/boot.rs#L414) for a full definition of the fields within it.

--- a/features/verifiable-cloud/quickstart.mdx
+++ b/features/verifiable-cloud/quickstart.mdx
@@ -273,6 +273,10 @@ In the dashboard you will see "Action Required" transition to "none". This means
 
 Our infrastructure automatically provisions network ingress for your application. You can visit `https://app-<YOUR_APP_UUID>.turnkey.cloud` to interact with it. If you used our `helloworld` template, try visiting `/time` in your browser!
 
+<Note>
+Only HTTP applications can receive public ingress right now. See [Networking and ingress](/features/verifiable-cloud/overview#networking-and-ingress) for details.
+</Note>
+
 ### Verify your deployment
 
 Once the deployment is live, confirm it is healthy by hitting the `/health` endpoint. Before doing so, check the deployment details from the previous step and ensure **Healthy Replicas** reads `3/3`. If replicas aren't fully up yet, the endpoint may return a 404.

--- a/features/verifiable-cloud/quickstart.mdx
+++ b/features/verifiable-cloud/quickstart.mdx
@@ -274,7 +274,7 @@ In the dashboard you will see "Action Required" transition to "none". This means
 Our infrastructure automatically provisions network ingress for your application. You can visit `https://app-<YOUR_APP_UUID>.turnkey.cloud` to interact with it. If you used our `helloworld` template, try visiting `/time` in your browser!
 
 <Note>
-Only HTTP applications can receive public ingress right now. See [Networking and ingress](/features/verifiable-cloud/overview#networking-and-ingress) for details.
+Only HTTP/1 applications can receive public ingress right now. See [Networking and ingress](/features/verifiable-cloud/overview#networking-and-ingress) for details.
 </Note>
 
 ### Verify your deployment


### PR DESCRIPTION
Documents that only HTTP applications can currently receive public ingress on TVC. 

Changes
- `overview.mdx`: Add a **Networking and ingress** section covering the dedicated `turnkey.cloud` subdomain, load-balanced ingress, and the HTTP-only restriction. 
- `quickstart.mdx`: Add a `<Note>` callout at the ingress step linking to the above section.


Closes [TVC-148](https://linear.app/turnkey/issue/TVC-148/document-that-only-http-apps-can-get-public-ingress-right-now)