### PR TITLE
docs(api-reference): add set_tvc_app_live_deployment activity page

### DIFF
--- a/api-reference/activities/set-tvc-app-live-deployment.mdx
+++ b/api-reference/activities/set-tvc-app-live-deployment.mdx
@@ -1,0 +1,181 @@
+---
+title: "Set TVC App live deployment"
+description: "Set the live deployment for a TVC App"
+---
+
+import { Authorizations } from "/snippets/api/authorizations.mdx";
+import { H3Bordered } from "/snippets/h3-bordered.mdx";
+import { NestedParam } from "/snippets/nested-param.mdx";
+import { EndpointPath } from "/snippets/api/endpoint.mdx";
+
+<EndpointPath type="submit" path="set_tvc_app_live_deployment" />
+
+<Authorizations />
+
+<H3Bordered text="Body" />
+
+<ParamField body="type" type="enum<string>" required={true}>
+
+Enum options: `ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT`
+</ParamField>
+
+<ParamField body="timestampMs" type="string" required={true}>
+
+Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+</ParamField>
+
+<ParamField body="organizationId" type="string" required={true}>
+
+Unique identifier for a given Organization.
+</ParamField>
+
+<ParamField body="parameters" type="object" required={true} path="parameters">
+  <p>The parameters object containing the specific intent data for this activity.</p>
+  <Expandable title="details">
+    <NestedParam parentKey="parameters" childKey="deploymentId" type="string" required={true} default="">
+    The unique identifier of the TVC deployment to set as live for the app.
+    </NestedParam>
+  </Expandable>
+</ParamField>
+<ParamField body="generateAppProofs" type="boolean" required={false}>
+
+Enable to have your activity generate and return App Proofs, enabling verifiability.
+</ParamField>
+
+
+<H3Bordered text="Response" />
+A successful response returns the following fields:
+
+<ResponseField name="activity" type="object" required={true}>
+  The activity object containing type, intent, and result
+  <Expandable title="activity details">
+    <NestedParam parentKey="activity" childKey="id" type="string" required={true}>
+Unique identifier for a given Activity object.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="organizationId" type="string" required={true}>
+Unique identifier for a given Organization.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="status" type="string" required={true}>
+The activity status
+</NestedParam>
+<NestedParam parentKey="activity" childKey="type" type="string" required={true}>
+The activity type
+</NestedParam>
+<NestedParam parentKey="activity" childKey="intent" type="object" required={true}>
+      The intent of the activity
+      <Expandable title="intent details">
+        <NestedParam parentKey="activity.intent" childKey="updateTvcAppLiveDeploymentIntent" type="object" required={true}>
+      The updateTvcAppLiveDeploymentIntent object
+      <Expandable title="updateTvcAppLiveDeploymentIntent details">
+        <NestedParam parentKey="activity.intent.updateTvcAppLiveDeploymentIntent" childKey="deploymentId" type="string" required={true}>
+The unique identifier of the TVC deployment to set as live for the app.
+</NestedParam>
+
+      </Expandable>
+    </NestedParam>
+
+      </Expandable>
+    </NestedParam>
+<NestedParam parentKey="activity" childKey="result" type="object" required={true}>
+      The result of the activity
+      <Expandable title="result details">
+        <NestedParam parentKey="activity.result" childKey="updateTvcAppLiveDeploymentResult" type="object" required={true}>
+      The updateTvcAppLiveDeploymentResult object
+</NestedParam>
+
+      </Expandable>
+    </NestedParam>
+<NestedParam parentKey="activity" childKey="votes" type="array" required={true}>
+A list of objects representing a particular User's approval or rejection of a Consensus request, including all relevant metadata.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="fingerprint" type="string" required={true}>
+An artifact verifying a User's action.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="canApprove" type="boolean" required={true}>
+Whether the activity can be approved.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="canReject" type="boolean" required={true}>
+Whether the activity can be rejected.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="createdAt" type="string" required={true}>
+The creation timestamp.
+</NestedParam>
+<NestedParam parentKey="activity" childKey="updatedAt" type="string" required={true}>
+The last update timestamp.
+</NestedParam>
+
+  </Expandable>
+</ResponseField>
+
+<RequestExample>
+
+```bash title="cURL"
+curl --request POST \
+  --url https://api.turnkey.com/public/v1/submit/set_tvc_app_live_deployment \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header "X-Stamp: <string> (see Authorizations)" \
+  --data '{
+    "type": "ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT",
+    "timestampMs": "<string> (e.g. 1746736509954)",
+    "organizationId": "<string> (Your Organization ID)",
+    "parameters": {
+        "deploymentId": "<string>"
+    }
+}'
+```
+
+```javascript title="JavaScript"
+import { Turnkey } from "@turnkey/sdk-server";
+
+const turnkeyClient = new Turnkey({
+  apiBaseUrl: "https://api.turnkey.com",
+  apiPublicKey: process.env.API_PUBLIC_KEY!,
+  apiPrivateKey: process.env.API_PRIVATE_KEY!,
+  defaultOrganizationId: process.env.ORGANIZATION_ID!,
+});
+
+const response = await turnkeyClient.apiClient().updateTvcAppLiveDeployment({
+  deploymentId: "<string> (The unique identifier of the TVC deployment to set as live for the app.)"
+});
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "activity": {
+    "id": "<activity-id>",
+    "status": "ACTIVITY_STATUS_COMPLETED",
+    "type": "ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT",
+    "organizationId": "<organization-id>",
+    "timestampMs": "<timestamp> (e.g. 1746736509954)",
+    "result": {
+      "activity": {
+        "id": "<string>",
+        "organizationId": "<string>",
+        "status": "<string>",
+        "type": "<string>",
+        "intent": {
+          "updateTvcAppLiveDeploymentIntent": {
+            "deploymentId": "<string>"
+          }
+        },
+        "result": {
+          "updateTvcAppLiveDeploymentResult": {}
+        },
+        "votes": "<array>",
+        "fingerprint": "<string>",
+        "canApprove": "<boolean>",
+        "canReject": "<boolean>",
+        "createdAt": "<string>",
+        "updatedAt": "<string>"
+      }
+    }
+  }
+}
+```
+
+</ResponseExample>

--- a/docs.json
+++ b/docs.json
@@ -568,6 +568,7 @@
                   "api-reference/activities/restore-a-tvc-deployment",
                   "api-reference/activities/set-ip-allowlist",
                   "api-reference/activities/set-organization-feature",
+                  "api-reference/activities/set-tvc-app-live-deployment",
                   "api-reference/activities/sign-frost-spark",
                   "api-reference/activities/sign-raw-payload",
                   "api-reference/activities/sign-raw-payloads",

--- a/snippets/data/endpoint-tags.mdx
+++ b/snippets/data/endpoint-tags.mdx
@@ -781,6 +781,17 @@ export const endpoints = [
     ]
   },
   {
+    "name": "Set TVC App live deployment",
+    "id": "set-tvc-app-live-deployment",
+    "type": "activity",
+    "tags": [
+      {
+        "id": "tvc",
+        "label": "TVC"
+      }
+    ]
+  },
+  {
     "name": "Sign Frost Spark",
     "id": "sign-frost-spark",
     "type": "activity",


### PR DESCRIPTION
## What

Adds the missing API-reference page for the public `UPDATE_TVC_APP_LIVE_DEPLOYMENT`
activity (HTTP path `submit/set_tvc_app_live_deployment`, SDK method
`updateTvcAppLiveDeployment`).

- **New** `api-reference/activities/set-tvc-app-live-deployment.mdx`: hand-authored, modeled on
  the existing `restore-a-tvc-deployment.mdx` page.
- **Edit** `snippets/data/endpoint-tags.mdx`: adds the `set-tvc-app-live-deployment` entry under
  the TVC tag.
- **Edit** `docs.json`: adds the page to the Activities nav group.

## Why it's hand-authored

The docs OpenAPI generator (`scripts/openapi-gen`) silently drops this endpoint, so `make gen`
produces no page for it. The generator derives the intent/result/activity-type names it looks for
from the **HTTP path verb** (`set_`), but the proto message/enum use `Update`
(`UpdateTvcAppLiveDeploymentIntent`, `ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT`). No match →
the endpoint is dropped with no warning or error. Until the generator is fixed, the page is
maintained by hand.

## Testing

- `docs.json` nav entry, tag entry, and page slug are consistent
  (`set-tvc-app-live-deployment`).
- Page renders following the same structure as other TVC activity pages.


Closes [TVC-161](https://linear.app/turnkey/issue/TVC-161/add-api-reference-docs-for-the-public-update-tvc-app-live-deployment)