### PR TITLE
docs(policies): document public TVC activities in policy language ref…

### DIFF
--- a/features/policies/language.mdx
+++ b/features/policies/language.mdx
@@ -325,6 +325,17 @@ Valid `activity.action` values are `CREATE`, `UPDATE`, `DELETE`, `SIGN`, `EXPORT
 | **WEBHOOK_ENDPOINT**         | CREATE |         ACTIVITY_TYPE_CREATE_WEBHOOK_ENDPOINT |
 |                              | UPDATE |         ACTIVITY_TYPE_UPDATE_WEBHOOK_ENDPOINT |
 |                              | DELETE |         ACTIVITY_TYPE_DELETE_WEBHOOK_ENDPOINT |
+| **TVC_APP**                  | CREATE |                   ACTIVITY_TYPE_CREATE_TVC_APP |
+|                              | UPDATE |  ACTIVITY_TYPE_UPDATE_TVC_APP_LIVE_DEPLOYMENT |
+|                              | DELETE |  ACTIVITY_TYPE_DELETE_TVC_APP_AND_DEPLOYMENTS |
+| **TVC_DEPLOYMENT**           | CREATE |            ACTIVITY_TYPE_CREATE_TVC_DEPLOYMENT |
+|                              | UPDATE |   ACTIVITY_TYPE_CREATE_TVC_MANIFEST_APPROVALS |
+|                              | UPDATE |          ACTIVITY_TYPE_RESTORE_TVC_DEPLOYMENT |
+|                              | UPDATE |        ACTIVITY_TYPE_POST_TVC_QUORUM_KEY_SHARE |
+|                              | DELETE |            ACTIVITY_TYPE_DELETE_TVC_DEPLOYMENT |
+| **TVC_OPERATOR**             | CREATE |              ACTIVITY_TYPE_CREATE_TVC_OPERATOR |
+| **TVC_QUORUM_KEY**           | CREATE |            ACTIVITY_TYPE_CREATE_TVC_QUORUM_KEY |
+|                              | ENCRYPT | ACTIVITY_TYPE_RE_ENCRYPT_TVC_QUORUM_KEY_SHARE |
 
 <Note>
   ** In the Activity breakdown table above, `**` marks legacy features


### PR DESCRIPTION
## What

Documents Turnkey Verifiable Cloud (TVC) activities on the policy language reference page (`features/policies/language.mdx`):

- Adds the 7 public TVC activities to the `Activity types by resource and action` table (3 under `TVC_APP`, 4 under `TVC_DEPLOYMENT`), which previously listed no TVC rows.

Why

The page enumerated TVC resources but had no TVC rows in the `Activity types by resource and action` table. 

## Testing

Ran `mintlify dev` to verify changes locally.

## Ticket

Closes [TVC-163](https://linear.app/turnkey/issue/TVC-163/document-tvc-activities-on-the-policy-language-page)