### PR TITLE
docs(policies): add multi-approver across-tags example with per-tag m…

### DIFF
--- a/features/policies/examples/access-control.mdx
+++ b/features/policies/examples/access-control.mdx
@@ -37,6 +37,19 @@ sidebarTitle: "Access control"
 }
 ```
 
+#### Require multiple approvers across tags, with per-tag minimums
+
+This policy allows the activity only when every approver holds at least one of three tags, with **at least 1** approver from Tag A and **at least 2** approvers from Tag B or Tag C. The leading `approvers.any(...)` establishes the eligible voter set (Tag A, B, or C), and the `approvers.filter(...).count()` clauses enforce each minimum.
+
+```json
+{
+  "policyName": "Require 1 approver from Tag A and 2 approvers from Tag B or Tag C",
+  "effect": "EFFECT_ALLOW",
+  "consensus": "approvers.any(user, user.tags.contains('<TAG_A_ID>') || user.tags.contains('<TAG_B_ID>') || user.tags.contains('<TAG_C_ID>')) && (approvers.filter(user, user.tags.contains('<TAG_A_ID>')).count() >= 1 && approvers.filter(user, user.tags.contains('<TAG_B_ID>') || user.tags.contains('<TAG_C_ID>')).count() >= 2)",
+  "condition": "activity.resource == 'POLICY' && (activity.action == 'CREATE' || activity.action == 'UPDATE' || activity.action == 'DELETE')"
+}
+```
+
 #### Deny all delete actions for users with a specific tag
 
 ```json

--- a/features/policies/examples/access-control.mdx
+++ b/features/policies/examples/access-control.mdx
@@ -37,6 +37,8 @@ sidebarTitle: "Access control"
 }
 ```
 
+The filter can match multiple tags: `user.tags.contains('<TAG_A>') || user.tags.contains('<TAG_B>')` would require two approvers in total from either tag, in any combination. This counts a **total**; see below for enforcing a separate minimum per tag.
+
 #### Require multiple approvers across tags, with per-tag minimums
 
 This policy requires **at least 1** approver tagged `<SECURITY_TAG_ID>` and **at least 2** approvers tagged `<OPS_TAG_ID>` to create, update, or delete policies. A user carrying both tags counts toward both minimums.

--- a/features/policies/examples/access-control.mdx
+++ b/features/policies/examples/access-control.mdx
@@ -39,13 +39,13 @@ sidebarTitle: "Access control"
 
 #### Require multiple approvers across tags, with per-tag minimums
 
-This policy allows the activity only when every approver holds at least one of three tags, with **at least 1** approver from Tag A and **at least 2** approvers from Tag B or Tag C. The leading `approvers.any(...)` establishes the eligible voter set (Tag A, B, or C), and the `approvers.filter(...).count()` clauses enforce each minimum.
+This policy requires **at least 1** approver tagged `<SECURITY_TAG_ID>` and **at least 2** approvers tagged `<OPS_TAG_ID>` to create, update, or delete policies. The leading `approvers.any(...)` establishes the eligible voter set (SECURITY or OPS), and the `approvers.filter(...).count()` clauses enforce each minimum.
 
 ```json
 {
-  "policyName": "Require 1 approver from Tag A and 2 approvers from Tag B or Tag C",
+  "policyName": "Require 1 security + 2 ops approvers for policy changes",
   "effect": "EFFECT_ALLOW",
-  "consensus": "approvers.any(user, user.tags.contains('<TAG_A_ID>') || user.tags.contains('<TAG_B_ID>') || user.tags.contains('<TAG_C_ID>')) && (approvers.filter(user, user.tags.contains('<TAG_A_ID>')).count() >= 1 && approvers.filter(user, user.tags.contains('<TAG_B_ID>') || user.tags.contains('<TAG_C_ID>')).count() >= 2)",
+  "consensus": "approvers.any(user, user.tags.contains('<SECURITY_TAG_ID>') || user.tags.contains('<OPS_TAG_ID>')) && (approvers.filter(user, user.tags.contains('<SECURITY_TAG_ID>')).count() >= 1 && approvers.filter(user, user.tags.contains('<OPS_TAG_ID>')).count() >= 2)",
   "condition": "activity.resource == 'POLICY' && (activity.action == 'CREATE' || activity.action == 'UPDATE' || activity.action == 'DELETE')"
 }
 ```

--- a/features/policies/examples/access-control.mdx
+++ b/features/policies/examples/access-control.mdx
@@ -39,7 +39,7 @@ sidebarTitle: "Access control"
 
 #### Require multiple approvers across tags, with per-tag minimums
 
-This policy requires **at least 1** approver tagged `<SECURITY_TAG_ID>` and **at least 2** approvers tagged `<OPS_TAG_ID>` to create, update, or delete policies. The leading `approvers.any(...)` establishes the eligible voter set (SECURITY or OPS), and the `approvers.filter(...).count()` clauses enforce each minimum.
+This policy requires **at least 1** approver tagged `<SECURITY_TAG_ID>` and **at least 2** approvers tagged `<OPS_TAG_ID>` to create, update, or delete policies. A user carrying both tags counts toward both minimums.
 
 ```json
 {


### PR DESCRIPTION
## What

Adds Access control  policy example for multi-approvers.

Closes [CUS-233](https://linear.app/turnkey/issue/CUS-233/add-policy-example-to-access-control-docs)