### PR TITLE
Am/tvc 73/doc verification flow app proofs

### DIFF
--- a/features/verifiable-cloud/onboarding.mdx
+++ b/features/verifiable-cloud/onboarding.mdx
@@ -31,8 +31,7 @@ As you build, two concepts are worth reading up front:
 
 | Limitation  | Workaround   |
 | :-----------| :----------- |
-| Deployment deletion not implemented       | Ask our team on Slack, or simply kick-off another deploy. There can only be one live deployment at a time. Kicking off a new deployment automatically deletes any existing one |
-| No metrics or logs in dashboard         | Ask our team on Slack |
+| No metrics in dashboard         | Ask our team on Slack |
 | No egress connectivity  | Pass signed data as input to your API instead of fetching it from within the TEE |
 | Custom provisioning not self-serve | Ask our team on Slack, or use static provisioning
 

--- a/features/verifiable-cloud/onboarding.mdx
+++ b/features/verifiable-cloud/onboarding.mdx
@@ -22,6 +22,11 @@ Start with our minimal template and deploy it within your TVC-enabled organizati
 
 Verify it comes up healthy, and confirm one or more endpoints respond correctly. Once the baseline is confirmed, layer your application logic incrementally.
 
+As you build, two concepts are worth reading up front:
+
+- [Manifest sets and share sets](/features/verifiable-cloud/manifest-sets-and-share-sets) — the two operator sets that govern your app: who approves what code runs, and who guards the Quorum Key. Includes a worked example of setting thresholds for production.
+- [Proofs and verification](/features/verifiable-cloud/proofs-and-verification) — how to produce App Proofs from your enclave and how a client verifies them end-to-end, with links to working example apps in [`tkhq/tvc-examples`](https://github.com/tkhq/tvc-examples).
+
 ## Known platform limitations
 
 | Limitation  | Workaround   |

--- a/features/verifiable-cloud/proofs-and-verification.mdx
+++ b/features/verifiable-cloud/proofs-and-verification.mdx
@@ -97,8 +97,19 @@ Open-source tooling is available in:
 - [TypeScript](https://github.com/tkhq/sdk/tree/main/packages/crypto/src/proof.ts)
 - [Go](https://github.com/tkhq/go-sdk/tree/main/pkg/proofs)
 
+## Example applications
+
+The fastest way to see the full producer-and-verifier flow is to read a working app. The [`tkhq/tvc-examples`](https://github.com/tkhq/tvc-examples) repository has end-to-end examples, and the [`tkhq/tvc-template`](https://github.com/tkhq/tvc-template) starter includes a minimal proof route:
+
+- **Minimal producer (Rust).** The template's [`/random_app_proof`](https://github.com/tkhq/tvc-template/blob/main/crates/helloworld/src/handlers/keys.rs) route signs a payload with the enclave Ephemeral Key and returns the standard `{ scheme, publicKey, proofPayload, signature }` envelope. It's the smallest thing that produces a valid App Proof, and a good place to start.
+- **Custom proof type (Rust).** [`tvc-cosign`](https://github.com/tkhq/tvc-examples/tree/main/tvc-cosign) defines its own `APP_PROOF_TYPE_COSIGN_DECISION` payload committing to the wallet, transaction, classification, and the key that stamped the request. Its [`src/proof.rs`](https://github.com/tkhq/tvc-examples/blob/main/tvc-cosign/src/proof.rs) shows how to design a typed payload and sign it with the Ephemeral Key.
+- **Producer plus client-side verifier (Go + TypeScript).** [`tvc-chainalysis`](https://github.com/tkhq/tvc-examples/tree/main/tvc-chainalysis) produces a `sanctionsCheckProof` App Proof from a Go enclave app ([`apps/tvc-app/proof.go`](https://github.com/tkhq/tvc-examples/blob/main/tvc-chainalysis/apps/tvc-app/proof.go)) and verifies it in the browser ([`apps/web/components/ProofBadge.tsx`](https://github.com/tkhq/tvc-examples/blob/main/tvc-chainalysis/apps/web/components/ProofBadge.tsx)): it checks the App Proof signature with WebCrypto and confirms the App Proof public key matches the Ephemeral Key in the fetched Boot Proof. This is the [verification flow](#verification-flow) above, in code.
+
+Each example defines its own proof type and payload schema, but all sign with the Ephemeral Key, so the same Boot Proof linkage and verification steps apply regardless of what the payload commits to.
+
 ## See also
 
+- [`tkhq/tvc-examples`](https://github.com/tkhq/tvc-examples) — end-to-end example apps that produce and verify App Proofs (see [Example applications](#example-applications)).
 - [Turnkey Verified](https://docs.turnkey.com/security/turnkey-verified) — the user-facing feature built on these proofs, including supported App Proof types and example payloads.
 - [Deployment Lifecycle](https://docs.turnkey.com/features/verifiable-cloud/overview) — how an enclave gets from a container image to a running, attested instance.
 - [AWS Nitro Enclaves: Verifying the root of trust](https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html).


### PR DESCRIPTION
# Summary

- `onboarding.mdx`
  - Added a **concepts worth reading up front** section linking the **Manifest sets and share sets** and **Proofs and verification** pages.
  - Trimmed the **Known platform limitations** table: removed the stale **Deployment deletion not implemented** row, and narrowed **No metrics or logs in dashboard** to **No metrics in dashboard** now that logs are available.
- `proofs-and-verification.mdx`
  - Added an **Example applications** section referencing the `tvc-template /random_app_proof` route, `tvc-cosign`, and `tvc-chainalysis`.
  - Added a `tvc-examples` entry to `See also`

# Ticket

Closes [TVC-73](https://linear.app/turnkey/issue/TVC-73/better-documentation-verification-flow-manifest-vs-share-set-app)