### PR TITLE
docs(spark): clarify Spark signature cost per operation

### DIFF
--- a/features/networks/spark.mdx
+++ b/features/networks/spark.mdx
@@ -112,6 +112,16 @@ Turnkey supports every Spark wallet operation. For a runnable walkthrough of eac
 | Static deposit         | Bitcoin L1 → Spark (reusable address)                                                                                                    | `CREATE_WALLET_ACCOUNTS`, `EXPORT_WALLET_ACCOUNT`, `SIGN_TRANSACTION`                                                                  |
 | Token transfer         | Spark token operations (mint, transfer)                                                                                                  | `SIGN_RAW_PAYLOAD`                                                                                                                     |
 
+<Note>
+  Unlike most networks, one Spark action needs more than one wallet signature.
+  The enclave does not call the Spark Operators. Your client sends each FROST
+  step. Thus a send needs 2 signatures. A claim or a withdrawal needs 3. A leaf
+  split adds more signatures. A read also needs a signature, because Turnkey
+  signs with your identity key to get the data from the Operators. Calculate the
+  cost for each operation, not for each transfer. To control your costs, do not
+  read balances on a timer.
+</Note>
+
 ## Security model
 
 ### Pre-signed exit transactions must be secured

--- a/features/networks/spark.mdx
+++ b/features/networks/spark.mdx
@@ -113,13 +113,26 @@ Turnkey supports every Spark wallet operation. For a runnable walkthrough of eac
 | Token transfer         | Spark token operations (mint, transfer)                                                                                                  | `SIGN_RAW_PAYLOAD`                                                                                                                     |
 
 <Note>
-  Unlike most networks, one Spark action needs more than one wallet signature.
-  The enclave does not call the Spark Operators. Your client sends each FROST
-  step. Thus a send needs 2 signatures. A claim or a withdrawal needs 3. A leaf
-  split adds more signatures. A read also needs a signature, because Turnkey
-  signs with your identity key to get the data from the Operators. Calculate the
-  cost for each operation, not for each transfer. To control your costs, do not
-  read balances on a timer.
+  Spark operations can use multiple billable Turnkey signing requests:
+
+  - Send: 2
+  - Claim or cooperative withdrawal: 3
+  - Leaf swap: 5 more per batch
+
+  These base counts assume valid Operator and SSP sessions. One FROST request
+  covers all selected leaves in a batch.
+
+  The SDK calls the Spark Operators. The Turnkey enclave handles signing and
+  package construction.
+
+  Creating or renewing an Operator or SSP session requires an identity-key
+  signature. Reads reuse the session token. Reuse the same wallet instance.
+  For sats, use balance events with `getCachedBalance()` instead of polling
+  `getBalance()`.
+
+  To control costs, keep Operator and SSP sessions alive rather than letting
+  them expire and re-authenticating, and batch leaf operations where you can —
+  each session renewal and each unbatched leaf costs its own signature.
 </Note>
 
 ## Security model

--- a/features/networks/spark.mdx
+++ b/features/networks/spark.mdx
@@ -104,9 +104,9 @@ Turnkey supports every Spark wallet operation. For a runnable walkthrough of eac
 | Operation              | Direction                                                                                                                                | Turnkey activities used                                                                                                                |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | Deposit                | Bitcoin L1 → Spark (single-use address; also produces the [pre-signed exit transactions](#pre-signed-exit-transactions-must-be-secured)) | `SIGN_TRANSACTION`, `SPARK_SIGN_FROST`                                                                                                 |
-| Cooperative withdrawal | Spark → Bitcoin L1 (fast path; requires SO co-signing; falls back to unilateral exit below if SOs are unavailable)                       | `SPARK_SIGN_FROST`, `SPARK_PREPARE_TRANSFER`                                                                                           |
+| Cooperative withdrawal | Spark → Bitcoin L1 (fast path; requires SO co-signing; falls back to unilateral exit below if SOs are unavailable)                       | `SPARK_SIGN_FROST`, `SPARK_PREPARE_TRANSFER`, `SIGN_RAW_PAYLOAD`                                                                       |
 | Unilateral exit        | Spark → Bitcoin L1 (emergency path; no SO cooperation needed)                                                                            | none at exit time; broadcasts the [pre-signed exit transactions](#pre-signed-exit-transactions-must-be-secured) created during deposit |
-| Transfer               | Spark → Spark                                                                                                                            | `SPARK_SIGN_FROST`, `SPARK_PREPARE_TRANSFER` (sender); `SPARK_SIGN_FROST`, `SPARK_CLAIM_TRANSFER` (receiver)                           |
+| Transfer               | Spark → Spark                                                                                                                            | `SPARK_SIGN_FROST`, `SPARK_PREPARE_TRANSFER` (sender); `SPARK_SIGN_FROST`, `SPARK_CLAIM_TRANSFER`, `SIGN_RAW_PAYLOAD` (receiver)       |
 | Lightning receive      | Lightning → Spark                                                                                                                        | `SPARK_PREPARE_LIGHTNING_RECEIVE`                                                                                                      |
 | Lightning send         | Spark → Lightning                                                                                                                        | `SPARK_SIGN_FROST`, `SPARK_PREPARE_TRANSFER`                                                                                           |
 | Static deposit         | Bitcoin L1 → Spark (reusable address)                                                                                                    | `CREATE_WALLET_ACCOUNTS`, `EXPORT_WALLET_ACCOUNT`, `SIGN_TRANSACTION`                                                                  |
@@ -115,24 +115,22 @@ Turnkey supports every Spark wallet operation. For a runnable walkthrough of eac
 <Note>
   Spark operations can use multiple billable Turnkey signing requests:
 
-  - Send: 2
-  - Claim or cooperative withdrawal: 3
-  - Leaf swap: 5 more per batch
+- Send: 2
+- Claim or cooperative withdrawal: 3
+- Leaf swap: 5 additional requests per batch
 
-  These base counts assume valid Operator and SSP sessions. One FROST request
-  covers all selected leaves in a batch.
+These base counts assume valid Operator and SSP sessions. One FROST request
+covers all selected leaves in a batch.
 
-  The SDK calls the Spark Operators. The Turnkey enclave handles signing and
-  package construction.
+The SDK calls the Spark Operators. The Turnkey enclave handles signing and
+package construction.
 
-  Creating or renewing an Operator or SSP session requires an identity-key
-  signature. Reads reuse the session token. Reuse the same wallet instance.
-  For sats, use balance events with `getCachedBalance()` instead of polling
-  `getBalance()`.
+Creating or renewing an Operator or SSP session requires an identity-key
+signing request. The SDK reuses the session token for later reads. Keep the
+same wallet instance alive to preserve its SSP session and balance cache.
+For sats, use balance events with `getCachedBalance()` instead of polling
+`getBalance()`.
 
-  To control costs, keep Operator and SSP sessions alive rather than letting
-  them expire and re-authenticating, and batch leaf operations where you can —
-  each session renewal and each unbatched leaf costs its own signature.
 </Note>
 
 ## Security model


### PR DESCRIPTION
Spark actions require multiple wallet signatures because the enclave does not talk to the Spark Operators directly. Each FROST round is relayed by the client, so a send needs 2 signatures, and a claim or withdrawal needs 3. Reads also incur a signature, since Turnkey signs with the identity key to fetch data from the Operators.\n\nThis note sits under `## Supported operations` in `features/networks/spark.mdx` and sets cost expectations up front so integrators size activity budgets per operation rather than per transfer, and avoid polling balances on a timer.\n\nStems from customer billing surprises surfaced by Block (a Breeze partner).