### PR TITLE
Removing polygon from supported earn chains

### DIFF
--- a/api-reference/queries/get-earn-claim-fees-status.mdx
+++ b/api-reference/queries/get-earn-claim-fees-status.mdx
@@ -78,3 +78,4 @@ const response = await turnkeyClient.apiClient().getClaimEarnFeesStatus({
 ```
 
 </ResponseExample>
+

--- a/api-reference/queries/get-earn-deploy-status.mdx
+++ b/api-reference/queries/get-earn-deploy-status.mdx
@@ -78,3 +78,4 @@ const response = await turnkeyClient.apiClient().getEarnDeployStatus({
 ```
 
 </ResponseExample>
+

--- a/api-reference/queries/get-earn-deposit-status.mdx
+++ b/api-reference/queries/get-earn-deposit-status.mdx
@@ -78,3 +78,4 @@ const response = await turnkeyClient.apiClient().getEarnDepositStatus({
 ```
 
 </ResponseExample>
+

--- a/api-reference/queries/get-earn-withdraw-status.mdx
+++ b/api-reference/queries/get-earn-withdraw-status.mdx
@@ -78,3 +78,4 @@ const response = await turnkeyClient.apiClient().getEarnWithdrawStatus({
 ```
 
 </ResponseExample>
+

--- a/features/transaction-management/earn.mdx
+++ b/features/transaction-management/earn.mdx
@@ -41,7 +41,6 @@ A wrapper is deployed once per vault and fee configuration. After that, deposits
 | Ethereum | `eip155:1` | Morpho (Aave upcoming) |
 | Base | `eip155:8453` | Morpho (Aave upcoming) |
 | Arbitrum | `eip155:42161` | Morpho (Aave upcoming) |
-| Polygon | `eip155:137` | Morpho (Aave upcoming) |
 
 Earn is EVM-only in V1. The vault catalog only includes vaults with at least \$100k TVL.
 


### PR DESCRIPTION
Removing polygon from the list of supported earn chains and adding a newline to some api docs to try and bust the mintlify cache.