### PR TITLE
docs(tvc): document egress enablement in known limitations table

### DIFF
--- a/features/verifiable-cloud/onboarding.mdx
+++ b/features/verifiable-cloud/onboarding.mdx
@@ -32,7 +32,7 @@ As you build, two concepts are worth reading up front:
 | Limitation  | Workaround   |
 | :-----------| :----------- |
 | No metrics in dashboard         | Ask our team on Slack |
-| No egress connectivity  | Pass signed data as input to your API instead of fetching it from within the TEE |
+| Egress not self-serve  | Ask our team on Slack to enable egress for your organization |
 | Custom provisioning not self-serve | Ask our team on Slack, or use static provisioning
 
 ## Getting help


### PR DESCRIPTION
# Adds

Updates the Known Limitations table in Turnkey Verifiable Cloud onboarding doc to indicate egress availability upon request via Slack channels. 

# Ticket

Closes [CUS-288](https://linear.app/turnkey/issue/CUS-288/add-tvc-egress-limitation-to-known-limitations-table)