### PR TITLE
Am/cus 294/fix 404 earn pages

### DIFF
--- a/api-reference/queries/get-earn-claim-fees-status.mdx
+++ b/api-reference/queries/get-earn-claim-fees-status.mdx
@@ -28,9 +28,11 @@ The claim_request_id returned by ClaimEarnFees.
 <H3Bordered text="Response" />
 A successful response returns the following fields:
 
-<ResponseField name="status" type="enum" required={true}>Status of the fee claim.
-  
+<ResponseField name="status" type="enum" required={true}>
+Status of the fee claim.
+
 Enum options: `PENDING`, `COMPLETED`, `FAILED`
+
 </ResponseField>
 <ResponseField name="claimTxHash" type="string" required={false}>Transaction hash of the fee claim, once available.</ResponseField>
 <ResponseField name="error" type="string" required={false}>Reason the fee claim transaction failed, when status is FAILED.</ResponseField>

--- a/api-reference/queries/get-earn-deploy-status.mdx
+++ b/api-reference/queries/get-earn-deploy-status.mdx
@@ -28,9 +28,11 @@ The deploy_request_id returned by EarnDeployWrapper.
 <H3Bordered text="Response" />
 A successful response returns the following fields:
 
-<ResponseField name="status" type="enum" required={true}>Status of the wrapper deployment.
-  
+<ResponseField name="status" type="enum" required={true}>
+Status of the wrapper deployment.
+
 Enum options: `PENDING`, `COMPLETED`, `FAILED`
+
 </ResponseField>
 <ResponseField name="deployTxHash" type="string" required={false}>Transaction hash of the deployment, once available.</ResponseField>
 <ResponseField name="error" type="string" required={false}>Reason the deployment transaction failed, when status is FAILED.</ResponseField>

--- a/api-reference/queries/get-earn-deposit-status.mdx
+++ b/api-reference/queries/get-earn-deposit-status.mdx
@@ -28,9 +28,11 @@ The deposit_request_id returned by EarnDeposit.
 <H3Bordered text="Response" />
 A successful response returns the following fields:
 
-<ResponseField name="status" type="enum" required={true}>Status of the deposit.
-  
+<ResponseField name="status" type="enum" required={true}>
+Status of the deposit.
+
 Enum options: `PENDING`, `COMPLETED`, `FAILED`
+
 </ResponseField>
 <ResponseField name="depositTxHash" type="string" required={false}>Transaction hash of the deposit, once available.</ResponseField>
 <ResponseField name="error" type="string" required={false}>Reason the deposit transaction failed, when status is FAILED.</ResponseField>

--- a/api-reference/queries/get-earn-withdraw-status.mdx
+++ b/api-reference/queries/get-earn-withdraw-status.mdx
@@ -28,9 +28,11 @@ The withdraw_request_id returned by EarnWithdraw.
 <H3Bordered text="Response" />
 A successful response returns the following fields:
 
-<ResponseField name="status" type="enum" required={true}>Status of the withdrawal.
-  
+<ResponseField name="status" type="enum" required={true}>
+Status of the withdrawal.
+
 Enum options: `PENDING`, `COMPLETED`, `FAILED`
+
 </ResponseField>
 <ResponseField name="withdrawTxHash" type="string" required={false}>Transaction hash of the withdrawal, once available.</ResponseField>
 <ResponseField name="error" type="string" required={false}>Reason the withdrawal transaction failed, when status is FAILED.</ResponseField>

--- a/scripts/openapi-gen/utils/mdx-generator/generator.ts
+++ b/scripts/openapi-gen/utils/mdx-generator/generator.ts
@@ -228,9 +228,9 @@ export function generateResponseFieldMdxRecursive(
         : `<ResponseField name="${fieldName}" type="${fieldType}" required={${required}}>${description.trim()}</ResponseField>\n`;
     } else {
       // ANY NESTED Primitive: Use <NestedParam>
-      // NB: the trailing whitespace on the blank line below is load-bearing only
-      // in the sense that removing it reflows every existing nested enum field.
-      // The tag is already flow JSX, so the blank line is harmless. Leave as-is.
+      // Note: keep the trailing whitespace on the blank line below. The tag is
+      // already on its own line, so the blank line parses fine, and stripping
+      // the whitespace would reflow every nested enum field in api-reference/.
       mdx += `<NestedParam parentKey="${parentKey}" childKey="${fieldName}" type="${fieldType}" required={${required}}>\n${description.trim()}${
         isEnum
           ? `

--- a/scripts/openapi-gen/utils/mdx-generator/generator.ts
+++ b/scripts/openapi-gen/utils/mdx-generator/generator.ts
@@ -217,15 +217,20 @@ export function generateResponseFieldMdxRecursive(
 
     // Top-level Primitive: Use <ResponseField>
     if (!parentKey) {
-      mdx += `<ResponseField name="${fieldName}" type="${fieldType}" required={${required}}>${description.trim()}${
-        isEnum
-          ? `
-  ${generateEnumOptionsMdx(options)}`
-          : ""
-      }</ResponseField>
-`; // Removed newline before closing tag
+      // An enum body spans multiple paragraphs, so the opening tag goes on its
+      // own line. That makes it flow JSX, where blank lines between child
+      // paragraphs are valid. A plain description is a single paragraph, so it
+      // stays inline on the tag line.
+      mdx += isEnum
+        ? `<ResponseField name="${fieldName}" type="${fieldType}" required={${required}}>\n${description.trim()}\n${generateEnumOptionsMdx(
+            options
+          )}\n</ResponseField>\n`
+        : `<ResponseField name="${fieldName}" type="${fieldType}" required={${required}}>${description.trim()}</ResponseField>\n`;
     } else {
       // ANY NESTED Primitive: Use <NestedParam>
+      // NB: the trailing whitespace on the blank line below is load-bearing only
+      // in the sense that removing it reflows every existing nested enum field.
+      // The tag is already flow JSX, so the blank line is harmless. Leave as-is.
       mdx += `<NestedParam parentKey="${parentKey}" childKey="${fieldName}" type="${fieldType}" required={${required}}>\n${description.trim()}${
         isEnum
           ? `


### PR DESCRIPTION
# Summary

- Fixes generator to handle ENUM bodies
- regenerates the 4 Earn docs pages that currently `404`

# Ticket

[Closes CUS-294](https://linear.app/turnkey/issue/CUS-294/four-earn-status-query-pages-404-generator-emits-invalid-mdx-for-top)