### PR TITLE
Add Why TVC? page to Verifiable Cloud docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -466,6 +466,7 @@
                 "group": "Turnkey Verifiable Cloud",
                 "pages": [
                   "features/verifiable-cloud/overview",
+                  "features/verifiable-cloud/why-tvc",
                   "features/verifiable-cloud/onboarding",
                   "features/verifiable-cloud/quickstart",
                   "features/verifiable-cloud/manifest-sets-and-share-sets",

--- a/features/verifiable-cloud/why-tvc.mdx
+++ b/features/verifiable-cloud/why-tvc.mdx
@@ -2,11 +2,11 @@
 title: "Why TVC?"
 ---
 
+## TEEs don't matter if they aren't run correctly
+
 Anyone can rent a TEE. Almost no one runs them correctly.
 
 The security of a trusted execution environment is only as strong as everything around it: how code gets approved, how secrets get provisioned, how builds get reproduced, and how upgrades happen. TVC is the only enclave platform where all of it rolls up to the hardware root of trust.
-
-["TEEs don't matter if they aren't run correctly"](https://x.com/ZekeMostov/status/2086979086010769522?s=20)
 
 ## Trust minimization, not trust relocation
 

--- a/features/verifiable-cloud/why-tvc.mdx
+++ b/features/verifiable-cloud/why-tvc.mdx
@@ -2,26 +2,28 @@
 title: "Why TVC?"
 ---
 
+import { TvcBetaCallout } from "/snippets/tvc-beta-callout.mdx";
+
 ## TEEs don't matter if they aren't run correctly
 
 Anyone can rent a TEE. Almost no one runs them correctly.
 
-The security of a trusted execution environment is only as strong as everything around it: how code gets approved, how secrets get provisioned, how builds get reproduced, and how upgrades happen. TVC is the only enclave platform where all of it rolls up to the hardware root of trust.
+The security of a trusted execution environment is only as strong as everything around it: how code gets approved, how secrets get provisioned, how builds get reproduced, and how upgrades happen. TVC is the only enclave platform where the process itself rolls up to the hardware root of trust.
 
 ## Trust minimization, not trust relocation
 
-Most TEE platforms remove trust in the cloud provider and hand it to whoever operates the enclave. TVC removes the operator too.
+Most TEE platforms remove trust in the cloud provider and hand it to whoever operates the enclave. TVC removes trust in the operator too.
 
-* **Quorum approved code upgrades.** No single admin, insider, or compromised account can ship code to an enclave. Every change requires m-of-n cryptographic approval.
-* **Quorum based provisioning for core secrets.** Core secrets only reconstruct inside enclaves running quorum approved code. Each share holder independently verifies the attestation before posting their share.
+* **Quorum-approved code upgrades.** No single admin, insider, or compromised account can ship code to an enclave. Every change requires m-of-n cryptographic approval.
+* **Quorum-based provisioning for core secrets.** Core secrets only reconstruct inside enclaves running quorum-approved code. Each share holder independently verifies the attestation before posting their share.
 * **Fully reproducible everything.** The operating system ([QuorumOS](https://github.com/tkhq/qos)), the application, and the build system itself ([StageX](https://stagex.tools)) are deterministically reproducible. Anyone can rebuild from source and confirm the running enclave matches, bit for bit.
-* **Verify the whole machine, not just the binary.** Attestation covers the OS and application plus every aspect of configuration: environment variables, CLI arguments, firewall rules, and the set of people who approved the code. The hardware root of trust (the Nitro Secure Module) measures all of it.
+* **Verify the whole machine, not just the binary.** Attestation covers the OS and application plus every aspect of configuration: environment variables, CLI arguments, firewall rules, and the set of people who approved the code. The hardware root of trust (the Nitro Secure Module) accounts for all of it.
 
 ## A stable identity that survives upgrades
 
-The [Quorum Key](https://github.com/tkhq/qos#quorum-key) gives your application a core secret that persists across software upgrades with zero downtime. Upgrades stay gated by quorum approval, but enclave to enclave attestation carries the key forward automatically, so fleets scale with no human in the loop.
+The [Quorum Key](https://github.com/tkhq/qos#quorum-key) gives your application a core secret that persists across software upgrades with zero downtime. Upgrades stay gated by quorum approval, but enclave-to-enclave attestation carries the key forward automatically, so fleets scale with no human in the loop.
 
-* **Provably have no access to encrypted user data.** The guarantee comes from cryptography, not from policy.
+* **Operators provably have no access to encrypted user data.** The guarantee comes from cryptography, not from policy.
 * **Prove that no one else does either.** Your customers, auditors, and regulators can check the proof themselves.
 
 ## Fully verified TLS
@@ -30,7 +32,7 @@ On TVC, all of the code that verifies TLS rolls up into the Nitro Secure Module 
 
 ## Secure by default, open by choice
 
-Most confidential VM offerings start as a general purpose machine you must lock down. TVC starts from the most locked down possible configuration, built for processing targets holding billions of dollars. You selectively enable functionality like egress as you need it. Subtractive security fails quietly. Additive security fails safe.
+Most confidential VM offerings start as a general-purpose machine you must lock down. TVC starts from the most locked down possible configuration, built for processing targets holding billions of dollars. You selectively enable functionality like egress as you need it. Subtractive security fails quietly. Additive security fails safe.
 
 ## Part of the Turnkey stack
 
@@ -38,6 +40,6 @@ TVC interoperates natively with Turnkey's secret and key management system: poli
 
 ## Get started
 
-Make a Turnkey account, download the [TVC CLI](https://github.com/tkhq/rust-sdk/tree/main/tvc), and get everything above running with one prompt. See the [quickstart](/features/verifiable-cloud/quickstart) to deploy your first app.
+Make a Turnkey account and get everything above running with one prompt. See the [quickstart](/features/verifiable-cloud/quickstart) to deploy your first app.
 
-TVC is currently in private beta. [Join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist) to request access.
+<TvcBetaCallout />

--- a/features/verifiable-cloud/why-tvc.mdx
+++ b/features/verifiable-cloud/why-tvc.mdx
@@ -1,0 +1,43 @@
+---
+title: "Why TVC?"
+---
+
+Anyone can rent a TEE. Almost no one runs them correctly.
+
+The security of a trusted execution environment is only as strong as everything around it: how code gets approved, how secrets get provisioned, how builds get reproduced, and how upgrades happen. TVC is the only enclave platform where all of it rolls up to the hardware root of trust.
+
+["TEEs don't matter if they aren't run correctly"](https://x.com/ZekeMostov/status/2086979086010769522?s=20)
+
+## Trust minimization, not trust relocation
+
+Most TEE platforms remove trust in the cloud provider and hand it to whoever operates the enclave. TVC removes the operator too.
+
+* **Quorum approved code upgrades.** No single admin, insider, or compromised account can ship code to an enclave. Every change requires m-of-n cryptographic approval.
+* **Quorum based provisioning for core secrets.** Core secrets only reconstruct inside enclaves running quorum approved code. Each share holder independently verifies the attestation before posting their share.
+* **Fully reproducible everything.** The operating system ([QuorumOS](https://github.com/tkhq/qos)), the application, and the build system itself ([StageX](https://stagex.tools)) are deterministically reproducible. Anyone can rebuild from source and confirm the running enclave matches, bit for bit.
+* **Verify the whole machine, not just the binary.** Attestation covers the OS and application plus every aspect of configuration: environment variables, CLI arguments, firewall rules, and the set of people who approved the code. All of it is measured from the hardware root of trust (the Nitro Secure Module).
+
+## A stable identity that survives upgrades
+
+The [Quorum Key](https://github.com/tkhq/qos#quorum-key) gives your application a core secret that persists across software upgrades with zero downtime. Upgrades stay gated by quorum approval, but enclave to enclave attestation carries the key forward automatically, so fleets scale with no human in the loop.
+
+* **Provably have no access to encrypted user data.** Not a policy statement, a cryptographic one.
+* **Prove that no one else does either.** Your customers, auditors, and regulators can check the proof themselves.
+
+## Fully verified TLS
+
+On TVC, all of the code that verifies TLS rolls up into the Nitro Secure Module measurements, so even your connections to the outside world are part of the proof.
+
+## Secure by default, open by choice
+
+Most confidential VM offerings start as a general purpose machine you must lock down. TVC starts from the most locked down possible configuration, built for processing targets holding billions of dollars, and lets you selectively enable functionality like egress as you need it. Subtractive security fails quietly. Additive security fails safe.
+
+## Part of the Turnkey stack
+
+TVC interoperates natively with Turnkey's [secret](/features/secrets) and [key management](/features/wallets) system: policy gated key release, arbitrary consensus thresholds, and policies that can bind key access to exact application hashes and attestation contents.
+
+## Get started
+
+Make a Turnkey account, download the [TVC CLI](https://github.com/tkhq/rust-sdk/tree/main/tvc), and get everything above running with one prompt. See the [quickstart](/features/verifiable-cloud/quickstart) to deploy your first app.
+
+TVC is currently in private beta. [Join the waitlist](https://www.turnkey.com/turnkey-verifiable-cloud#waitlist) to request access.

--- a/features/verifiable-cloud/why-tvc.mdx
+++ b/features/verifiable-cloud/why-tvc.mdx
@@ -15,13 +15,13 @@ Most TEE platforms remove trust in the cloud provider and hand it to whoever ope
 * **Quorum approved code upgrades.** No single admin, insider, or compromised account can ship code to an enclave. Every change requires m-of-n cryptographic approval.
 * **Quorum based provisioning for core secrets.** Core secrets only reconstruct inside enclaves running quorum approved code. Each share holder independently verifies the attestation before posting their share.
 * **Fully reproducible everything.** The operating system ([QuorumOS](https://github.com/tkhq/qos)), the application, and the build system itself ([StageX](https://stagex.tools)) are deterministically reproducible. Anyone can rebuild from source and confirm the running enclave matches, bit for bit.
-* **Verify the whole machine, not just the binary.** Attestation covers the OS and application plus every aspect of configuration: environment variables, CLI arguments, firewall rules, and the set of people who approved the code. All of it is measured from the hardware root of trust (the Nitro Secure Module).
+* **Verify the whole machine, not just the binary.** Attestation covers the OS and application plus every aspect of configuration: environment variables, CLI arguments, firewall rules, and the set of people who approved the code. The hardware root of trust (the Nitro Secure Module) measures all of it.
 
 ## A stable identity that survives upgrades
 
 The [Quorum Key](https://github.com/tkhq/qos#quorum-key) gives your application a core secret that persists across software upgrades with zero downtime. Upgrades stay gated by quorum approval, but enclave to enclave attestation carries the key forward automatically, so fleets scale with no human in the loop.
 
-* **Provably have no access to encrypted user data.** Not a policy statement, a cryptographic one.
+* **Provably have no access to encrypted user data.** The guarantee comes from cryptography, not from policy.
 * **Prove that no one else does either.** Your customers, auditors, and regulators can check the proof themselves.
 
 ## Fully verified TLS
@@ -30,11 +30,11 @@ On TVC, all of the code that verifies TLS rolls up into the Nitro Secure Module 
 
 ## Secure by default, open by choice
 
-Most confidential VM offerings start as a general purpose machine you must lock down. TVC starts from the most locked down possible configuration, built for processing targets holding billions of dollars, and lets you selectively enable functionality like egress as you need it. Subtractive security fails quietly. Additive security fails safe.
+Most confidential VM offerings start as a general purpose machine you must lock down. TVC starts from the most locked down possible configuration, built for processing targets holding billions of dollars. You selectively enable functionality like egress as you need it. Subtractive security fails quietly. Additive security fails safe.
 
 ## Part of the Turnkey stack
 
-TVC interoperates natively with Turnkey's [secret](/features/secrets) and [key management](/features/wallets) system: policy gated key release, arbitrary consensus thresholds, and policies that can bind key access to exact application hashes and attestation contents.
+TVC interoperates natively with Turnkey's secret and key management system: policy gated key release, arbitrary consensus thresholds, and policies that can bind key access to exact application hashes and attestation contents.
 
 ## Get started
 


### PR DESCRIPTION
Adds a "Why TVC?" page to the Turnkey Verifiable Cloud section (right after Overview) covering what differentiates TVC from other TEE platforms:

- Trust minimization: quorum approved upgrades, quorum based secret provisioning, fully reproducible OS/app/build system, and attestation over the full configuration from the Nitro Secure Module
- Stable Quorum Key identity across upgrades with zero downtime, enabling provable no-access claims over encrypted user data
- Fully verified TLS rolling up into NSM measurements
- Locked down by default posture vs typical CVM offerings
- Native interop with Turnkey secrets and key management

🤖 Generated with [Claude Code](https://claude.com/claude-code)