### PR TITLE
docs(agentic-payments): fix ERC-20 transfer example to use ethSendTransaction

### DIFF
--- a/solutions/company-wallets/agentic-payments.mdx
+++ b/solutions/company-wallets/agentic-payments.mdx
@@ -97,13 +97,26 @@ The policy above restricts which contract the agent can interact with. To contro
 With gas sponsorship enabled, the agent doesn't need to hold ETH to pay for transaction fees. Turnkey covers gas so the agent can transact using only its USDC balance:
 
 ```ts
-const sendTransactionStatusId = await agentClient.ethSendErc20Transfer({
-  transfer: {
+import { encodeFunctionData, erc20Abi } from "viem";
+
+const recipient = "0xRecipientAddress";
+const usdcAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base
+const amount = 1_000_000n; // 1 USDC (6 decimals)
+
+// Encode the ERC-20 transfer(address,uint256) calldata
+const data = encodeFunctionData({
+  abi: erc20Abi,
+  functionName: "transfer",
+  args: [recipient, amount],
+});
+
+const sendTransactionStatusId = await agentClient.ethSendTransaction({
+  transaction: {
     from: process.env.AGENT_WALLET_ADDRESS!,
-    to: "0xRecipientAddress",
-    tokenAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base
-    amount: "1000000", // 1 USDC (6 decimals)
+    to: usdcAddress, // send the tx to the token contract, not the recipient
     caip2: "eip155:8453",
+    data,
+    value: "0",
     sponsor: true,
   },
 });


### PR DESCRIPTION
## What
Fix broken code example in the Agentic Payments guide: `ethSendErc20Transfer` does not exist on `@turnkey/sdk-server`, causing runtime `TypeError` for any customer copy-pasting the example.

## Why
The current example teaches customers to call `agentClient.ethSendErc20Transfer(...)` on a client created from `@turnkey/sdk-server`. This method does NOT exist on `sdk-server` — it only exists on `@turnkey/core`. Every customer who follows the guide gets a runtime `TypeError` when trying to execute the code.

## How
Switched to the `ethSendTransaction` + viem `encodeFunctionData` pattern that is already used in `solutions/company-wallets/payment-orchestration.mdx` and documented throughout the rest of the Turnkey docs. This approach:
- Uses `ethSendTransaction` which is available on `@turnkey/sdk-server`
- Encodes ERC-20 `transfer(address,uint256)` calldata via viem's `encodeFunctionData` and `erc20Abi`
- Keeps `sponsor: true` so the agent still doesn't need ETH for gas
- Unlocks all EVM chains that `ethSendTransaction` supports (not just the subset a missing convenience method might have covered)

## Discovered by
A customer building an agentic BSC-testnet payment flow who hit the runtime `TypeError` when trying to execute the example code.

## Alternative considered and rejected
Porting `ethSendErc20Transfer` to `sdk-server`. This was rejected because:
- `sdk-server` is intentionally kept thin (no viem dep, no chain-abstraction convenience helpers)
- The client-side encoding pattern is already the documented idiom across Turnkey guides

## Follow-up (out of scope)
The Interfaces team may want to consider whether `ethSendErc20Transfer` should be deprecated on `core` for consistency. This is a separate conversation and does not block this fix.

## Changed files
- `solutions/company-wallets/agentic-payments.mdx` — Step "Send the USDC payout with gas sponsorship" updated from broken `ethSendErc20Transfer` pattern to working `ethSendTransaction` + viem `encodeFunctionData` pattern