### PR TITLE
Align the secrets docs with the shipped SDK helpers

### DIFF
--- a/features/secrets.mdx
+++ b/features/secrets.mdx
@@ -38,7 +38,7 @@ Secrets are created with optional **static properties**: string key-value pairs 
 
 ## Importing a secret
 
-The `importSecret` method in [`@turnkey/sdk-server`](/sdks/typescript-sdk) and [`@turnkey/core`](/sdks/typescript-sdk) handles the full flow. It initializes the ingress key, verifies the enclave signature, encrypts the secret, and submits the ciphertext:
+The `importSecret` method in [`@turnkey/sdk-server`](/sdks/introduction) handles the full flow. It initializes the ingress key, verifies the enclave signature, encrypts the secret, and submits the ciphertext:
 
 ```typescript
 const secretId = await turnkey.apiClient().importSecret({
@@ -51,13 +51,13 @@ const secretId = await turnkey.apiClient().importSecret({
 });
 ```
 
-For sensitive material you want wiped from memory after encryption, pass a `Uint8Array` instead of a string. The SDK zeroizes the buffer after it produces the ciphertext.
+Static properties are bound immutably at import time, so choose them with the policies you intend to write in mind. Names are unique within an organization.
 
-Under the hood this calls [init_import_secrets](/api-reference/activities/init-import-secrets) and [import_secrets](/api-reference/activities/import-secrets).
+Under the hood this calls `init_import_secrets`, which mints the single-use ingress target key, followed by [import_secrets](/api-reference/activities/import-secrets).
 
 ## Exporting a secret
 
-`exportSecret` generates the ephemeral keypair, submits the export activity, decrypts the result, and zeroizes the key. It is a single call when policy allows the caller to export unilaterally:
+`exportSecret` generates the ephemeral keypair, submits the export activity, polls it to completion, and decrypts the result. It is a single call when policy allows the caller to export unilaterally:
 
 ```typescript
 const plaintext = await turnkey.apiClient().exportSecret({
@@ -69,11 +69,17 @@ If the export requires additional approvals, `exportSecret` throws a consensus-n
 
 ## Listing secrets
 
-[list_secrets](/api-reference/queries/list-secrets) returns metadata: IDs, names, static properties, and creation timestamps:
+`getSecrets` returns metadata only: IDs, names, static properties, and creation timestamps. Plaintext never leaves the enclave on this path.
 
 ```typescript
-const { secrets } = await turnkey.apiClient().listSecrets({});
+const secrets = await turnkey.apiClient().getSecrets();
+
+for (const secret of secrets) {
+  console.log(secret.secretId, secret.name, secret.staticProperties);
+}
 ```
+
+It wraps [list_secrets](/api-reference/queries/list-secrets), returning the array directly with `staticProperties` as a `Record<string, string>` — the same shape `importSecret` accepts. Pass `paginationOptions` to page through a large organization.
 
 ## Multi-party approval
 
@@ -89,6 +95,15 @@ Turnkey is a signing and encryption platform running inside secure enclaves, ori
 - **Quantum resistant internally, agile in transit**: secrets rest under AES-256-GCM, a quantum resistant cipher. The transport cipher suite is a field in import and export requests, designed to be extended over time, so Turnkey can adopt new transport protocols as they mature.
 - **Forward secrecy**: ingress and egress target keys are single-use. Compromising one exposes at most one payload.
 - **Full auditability**: every import, export, and approval is an activity that is attributed to the authenticating credential, logged, and queryable.
+
+## Examples
+
+Two runnable examples in the SDK repo cover both flows end to end:
+
+| Example | Description |
+| --- | --- |
+| [`api-key-storage`](https://github.com/tkhq/sdk/tree/main/examples/key-management/api-key-storage) | Import an exchange API key, gate retrieval with a policy, list secrets, and export the plaintext |
+| [`programmable-credential-access`](https://github.com/tkhq/sdk/tree/main/examples/key-management/programmable-credential-access) | Two agent users co-sign the same export before the enclave releases a stored credit card |
 
 ## Next steps
 

--- a/features/secrets.mdx
+++ b/features/secrets.mdx
@@ -69,7 +69,7 @@ If the export requires additional approvals, `exportSecret` throws a consensus-n
 
 ## Listing secrets
 
-`getSecrets` returns metadata only: IDs, names, static properties, and creation timestamps. Plaintext never leaves the enclave on this path.
+`getSecrets` returns metadata only: IDs, names, static properties, and creation timestamps.
 
 ```typescript
 const secrets = await turnkey.apiClient().getSecrets();
@@ -79,7 +79,7 @@ for (const secret of secrets) {
 }
 ```
 
-It wraps [list_secrets](/api-reference/queries/list-secrets), returning the array directly with `staticProperties` as a `Record<string, string>` — the same shape `importSecret` accepts. Pass `paginationOptions` to page through a large organization.
+It wraps [list_secrets](/api-reference/queries/list-secrets), returning the array directly with `staticProperties` as a `Record<string, string>`.
 
 ## Multi-party approval
 

--- a/get-started/examples.mdx
+++ b/get-started/examples.mdx
@@ -39,6 +39,8 @@ Full end-to-end applications to see everything working together.
 | [`import-in-node`](https://github.com/tkhq/sdk/tree/main/examples/key-management/import-in-node) | Wallet import performed on the backend |
 | [`disaster-recovery`](https://github.com/tkhq/sdk/tree/main/examples/key-management/disaster-recovery) | Wallet disaster recovery with direct import or encryption key escrow |
 | [`encryption-key-escrow`](https://github.com/tkhq/sdk/tree/main/examples/key-management/encryption-key-escrow) | Use Turnkey to store encryption keys for external recovery bundles |
+| [`api-key-storage`](https://github.com/tkhq/sdk/tree/main/examples/key-management/api-key-storage) | Store an exchange API key as a secret, gate retrieval with a policy, and export it at runtime |
+| [`programmable-credential-access`](https://github.com/tkhq/sdk/tree/main/examples/key-management/programmable-credential-access) | Multi-agent consensus: two agent users co-sign a secret export, and only the recipient can decrypt it |
 
 ## Signing
 

--- a/solutions/key-management/api-key-storage.mdx
+++ b/solutions/key-management/api-key-storage.mdx
@@ -65,6 +65,10 @@ A trading firm holds a long-lived JWT for an execution management system that au
 
 ### Implementation steps
 
+<Note>
+  For a working end-to-end implementation, see the [api-key-storage example](https://github.com/tkhq/sdk/tree/main/examples/key-management/api-key-storage) — it imports the credential with static properties, creates the retrieval policy, lists the organization's secrets, and exports the plaintext as the trading service user.
+</Note>
+
 <Steps>
   <Step title="Import the API key">
     Import the credential once, with static properties the policies above target. The client encrypts the plaintext to the enclave. Turnkey's API and database only ever see ciphertext:
@@ -94,6 +98,8 @@ A trading firm holds a long-lived JWT for an execution management system that au
 
     // Use the JWT for REST or WebSocket calls, keep it in memory only
     ```
+
+    To find the secret ID at runtime rather than hard-coding it, list the organization's secrets with `getSecrets()` and match on the static properties you bound at import time. That path returns metadata only.
   </Step>
 
   <Step title="Require approval for high-risk keys">
@@ -108,7 +114,32 @@ A trading firm holds a long-lived JWT for an execution management system that au
     }
     ```
 
-    The export stays in `ACTIVITY_STATUS_CONSENSUS_NEEDED` until a risk admin approves it from the dashboard or via [approve_activity](/api-reference/activities/approve-activity), and the released payload is still readable only by the trading service.
+    `exportSecret` cannot be used for these keys: it fails fast with `EXPORT_SECRET_CONSENSUS_NEEDED` rather than waiting on approvals, because the ephemeral private key it generates internally would be lost by the time they arrive. Use the proposal helpers instead, which keep the decryption key in the trading service's hands across the approval window:
+
+    ```typescript
+    import { generateP256KeyPair } from "@turnkey/crypto";
+
+    // The export activity requires a 65-byte uncompressed target key.
+    const { privateKey, publicKeyUncompressed } = generateP256KeyPair();
+
+    const proposal = tradingService.createExportSecretsProposal({
+      secrets: [{ secretId }],
+      targetPublicKey: publicKeyUncompressed,
+      timestampMs: String(Date.now()),
+    });
+
+    const submission = await tradingService.submitExportSecrets(proposal);
+
+    // Blocks until the risk admin approves, then decrypts locally.
+    const [withdrawalKey] = await tradingService.awaitExportedSecrets({
+      proposal,
+      embeddedPrivateKey: privateKey,
+      activityId: submission.activityId,
+      timeoutMs: 15 * 60 * 1000,
+    });
+    ```
+
+    The export stays in `ACTIVITY_STATUS_CONSENSUS_NEEDED` until a risk admin approves it from the dashboard or via [approve_activity](/api-reference/activities/approve-activity), and the released payload is still readable only by the trading service. See [Programmable credential access](/solutions/key-management/programmable-credential-access) for the full multi-party flow.
   </Step>
 
   <Step title="Rotate and revoke">

--- a/solutions/key-management/api-key-storage.mdx
+++ b/solutions/key-management/api-key-storage.mdx
@@ -99,7 +99,7 @@ A trading firm holds a long-lived JWT for an execution management system that au
     // Use the JWT for REST or WebSocket calls, keep it in memory only
     ```
 
-    To find the secret ID at runtime rather than hard-coding it, list the organization's secrets with `getSecrets()` and match on the static properties you bound at import time. That path returns metadata only.
+    To find the secret ID at runtime rather than hard-coding it, list the organization's secrets with `getSecrets()`. That path returns metadata only.
   </Step>
 
   <Step title="Require approval for high-risk keys">

--- a/solutions/key-management/mpc-keyshare-storage.mdx
+++ b/solutions/key-management/mpc-keyshare-storage.mdx
@@ -49,7 +49,7 @@ Gate export on those properties. For example, require two recovery operators to 
 }
 ```
 
-At recovery time, the designated recovery participant generates an ephemeral keypair and retrieves the bundle with `exportSecret`, or with the proposal helpers described in [Programmable credential access](/solutions/key-management/programmable-credential-access) when the export requires additional approvals. Only that participant can decrypt the released bundle, which then re-enters your MPC provider's own recovery procedure.
+At recovery time, the designated recovery participant retrieves the bundle with `exportSecret`, which generates the ephemeral keypair internally and returns the plaintext in one call. When the export requires additional approvals, use the proposal helpers described in [Programmable credential access](/solutions/key-management/programmable-credential-access) instead: the participant generates its own keypair and holds the private half across the approval window. Only that participant can decrypt the released bundle, which then re-enters your MPC provider's own recovery procedure.
 
 ## Next steps
 

--- a/solutions/key-management/programmable-credential-access.mdx
+++ b/solutions/key-management/programmable-credential-access.mdx
@@ -58,6 +58,10 @@ Model a browser agent and a payment agent as durable Turnkey users, with session
 
 ### Implementation steps
 
+<Note>
+  For a working end-to-end implementation, see the [programmable-credential-access example](https://github.com/tkhq/sdk/tree/main/examples/key-management/programmable-credential-access) — it bootstraps both agent users, imports the credential, creates the consensus policy, and runs the parallel co-signed export.
+</Note>
+
 <Steps>
   <Step title="Import the credential">
     Import the card once, with static properties that the policy above targets. Any client with import permission can do this. Here, a backend service imports it:
@@ -80,12 +84,14 @@ Model a browser agent and a payment agent as durable Turnkey users, with session
     ```typescript
     import { generateP256KeyPair } from "@turnkey/crypto";
 
-    const { publicKey, privateKey } = generateP256KeyPair();
+    // The export activity requires a 65-byte uncompressed target key.
+    const { privateKey, publicKeyUncompressed } = generateP256KeyPair();
 
     const proposal = paymentAgent.createExportSecretsProposal({
       secrets: [{ secretId }],
-      targetPublicKey: publicKey,
+      targetPublicKey: publicKeyUncompressed,
       organizationId,
+      timestampMs: String(Date.now()),
     });
     ```
 
@@ -96,9 +102,21 @@ Model a browser agent and a payment agent as durable Turnkey users, with session
     Each agent instance stamps the identical proposal body with the session key for its durable agent-role user and submits. Order doesn't matter: the first submission creates the activity, and every subsequent identical submission counts as an approval.
 
     ```typescript
-    await Promise.all([
-      paymentAgent.submitExportSecrets(proposal),
-      browserAgent.submitExportSecrets(proposal),
+    import type { TurnkeyApiClient } from "@turnkey/sdk-server";
+
+    // If both submissions race to create the activity, the loser gets a
+    // conflict error and its retry lands as the approval vote.
+    const submit = async (agent: TurnkeyApiClient) => {
+      try {
+        return await agent.submitExportSecrets(proposal);
+      } catch (_) {
+        return await agent.submitExportSecrets(proposal);
+      }
+    };
+
+    const [paymentSubmission] = await Promise.all([
+      submit(paymentAgent),
+      submit(browserAgent),
     ]);
     ```
 
@@ -112,6 +130,7 @@ Model a browser agent and a payment agent as durable Turnkey users, with session
     const [cardJson] = await paymentAgent.awaitExportedSecrets({
       proposal,
       embeddedPrivateKey: privateKey,
+      activityId: paymentSubmission.activityId,
     });
 
     const card = JSON.parse(cardJson);


### PR DESCRIPTION
Brings the Secrets docs in line with what `@turnkey/sdk-server` actually ships, and links the two runnable examples from the SDK repo.

Every API claim here was checked against `packages/sdk-server/src/{secrets.ts,sdk-client.ts}`, and both examples were run end to end against `api.turnkey.com`.

## Corrections

- `listSecrets({})` → `getSecrets()`, which returns the array directly with `staticProperties` as a `Record<string, string>` — the same shape `importSecret` accepts.
- Dropped the `Uint8Array`/zeroize paragraph: `ImportSecretParams.plaintext` is `string` only.
- Dropped `@turnkey/core` from the `importSecret` sentence — core only has the raw generated `importSecrets` activity, not the helper.
- Unlinked `init_import_secrets`: there is no api-reference page for it.
- `targetPublicKey` now uses `publicKeyUncompressed` in both proposal snippets. The export activity requires the 65-byte uncompressed key, and the previous `publicKey` would be rejected.
- `createExportSecretsProposal` snippets pass `timestampMs`, which is required.
- `awaitExportedSecrets` snippets pass `activityId`.
- Fixed a broken link: `/sdks/typescript-sdk` → `/sdks/introduction`. `mintlify broken-links` goes from 7 to 6; the remaining 6 are pre-existing and unrelated.

## Additions

- api-key-storage: documents that `exportSecret` fails fast with `EXPORT_SECRET_CONSENSUS_NEEDED` rather than waiting on approvals, and shows the proposal-helper path that keeps the decryption key with the recipient across the approval window.
- programmable-credential-access: the parallel-submit snippet now handles the create race, where the loser resubmits and its retry lands as the approval vote.
- Both solution pages and `features/secrets.mdx` link the [`api-key-storage`](https://github.com/tkhq/sdk/tree/main/examples/key-management/api-key-storage) and [`programmable-credential-access`](https://github.com/tkhq/sdk/tree/main/examples/key-management/programmable-credential-access) examples, which are also listed in `get-started/examples.mdx`.

Depends on those examples landing in tkhq/sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)