### PR TITLE
docs(captcha): refine copy, add end-user screenshot, remove Early Access tags

### DIFF
--- a/features/authentication/captcha.mdx
+++ b/features/authentication/captcha.mdx
@@ -1,28 +1,35 @@
 ---
 title: "Captcha"
-description: "Protect your auth flows from bots and abuse using Cloudflare Turnstile Captcha, enabled through the Turnkey Dashboard."
+description: "Protect your auth flows from bots and abuse with Cloudflare Turnstile, configured in the Turnkey Dashboard."
 sidebarTitle: "Captcha"
-tag: "Early Access"
 ---
 
 Turnkey integrates [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/) to add Captcha protection to authentication flows. When enabled, Turnstile presents a lightweight, user-friendly challenge that blocks automated abuse such as bots, credential-stuffing attacks, and signup spam, all without disrupting the experience for real users.
 
+<Frame>
+  <img src="/images/authentication/img/captcha-end-user-widget.png" alt="Cloudflare Turnstile challenge shown to end users during sign-up and OTP request" />
+</Frame>
+
 Captcha protection is enforced at the two entry points most vulnerable to abuse:
 
 - **Requesting an email or SMS OTP**: captcha is required when the code is sent, covering both signup and login flows.
-- **Creating a new account (sub-organization)**: captcha is required during signup via passkey, OAuth / social login, or external wallet.
+- **Signing up a new user**: captcha is required when creating a new sub-org via passkey, OAuth / social login, or external wallet.
 
-Once a user has passed the captcha challenge when the OTP was sent, the subsequent OTP verification and login steps are not challenged again. They are protected by a one-time verification token instead. Existing-account logins via passkey, OAuth / social, or wallet are not captcha-challenged.
+Users are challenged once per flow. Passing the OTP challenge issues a one-time verification token that covers the code-entry and login steps that follow. Returning users signing in with a passkey, OAuth / social, or an external wallet are not challenged.
 
 ## Enabling Captcha
 
 Captcha protection is configured at the organization level in the Turnkey Dashboard. Once enabled, it is automatically enforced for the protected flows.
 
 <Warning>
-  **Automatic enforcement applies only to `@turnkey/react-wallet-kit` users.** The Turnstile widget is rendered and captcha tokens are attached for you — no code changes required.
-
-  If you build your auth UI directly on `@turnkey/core` (plain JavaScript, TypeScript, Vue, Svelte, Angular, or a custom React UI), **you must integrate captcha yourself** — render the Turnstile widget, obtain a token, and pass it to the relevant SDK methods. See the [integration guides](#integration-guides) below for your setup.
+  **SDK version requirement:** Captcha support is only available in `@turnkey/react-wallet-kit` v2.4.0 and above. Enabling captcha before updating your SDK will break authentication for your users.
 </Warning>
+
+<Note>
+  **Automatic enforcement applies only to `@turnkey/react-wallet-kit` users.** The Turnstile widget is rendered and captcha tokens are attached for you, no code changes required.
+
+  If you build your auth UI directly on `@turnkey/core` (plain JavaScript, TypeScript, Vue, Svelte, Angular, or a custom React UI), **you must integrate captcha yourself**: render the Turnstile widget, obtain a token, and pass it to the relevant SDK methods. See the [integration guides](#integration-guides) below for your setup.
+</Note>
 
 <Steps>
   <Step title="Open your Embedded Wallets Configuration">
@@ -44,7 +51,7 @@ Captcha protection is configured at the organization level in the Turnkey Dashbo
 </Steps>
 
 <Note>
-  Changes take effect immediately. Protected flows initiated through `@turnkey/react-wallet-kit` will display the Turnstile widget.
+  Changes take effect immediately for all traffic. Confirm every client session is on a supported SDK version before enabling. Older SDKs will not be able to sign up new users or send OTP codes once captcha is turned on.
 </Note>
 
 ## Integration guides

--- a/snippets/shared/captcha-core-basics.mdx
+++ b/snippets/shared/captcha-core-basics.mdx
@@ -51,7 +51,7 @@ const turnstileSiteKey = clientParams.turnstileSiteKey;
 </Note>
 
 <Note>
-  Captcha is in Early Access and is additionally gated per organization. If you've flipped the Dashboard toggle on but `getClientParams` still returns no site key, your organization hasn't been enabled for the feature yet, so reach out to Turnkey. The Auth Proxy won't enforce captcha in this state either, so your auth flows keep working.
+  Captcha is gated per organization. If you've flipped the Dashboard toggle on but `getClientParams` still returns no site key, your organization hasn't been enabled for the feature yet, so reach out to Turnkey. The Auth Proxy won't enforce captcha in this state either, so your auth flows keep working.
 </Note>
 
 ## Step 2: Render the widget

--- a/solutions/embedded-wallets/integration-guide/react-native/authentication/captcha.mdx
+++ b/solutions/embedded-wallets/integration-guide/react-native/authentication/captcha.mdx
@@ -2,7 +2,6 @@
 title: "Captcha"
 description: "Add Cloudflare Turnstile captcha protection to your React Native and Expo auth flows."
 sidebarTitle: "Captcha"
-tag: "Early Access"
 ---
 
 import CaptchaCoreBasics from "/snippets/shared/captcha-core-basics.mdx";

--- a/solutions/embedded-wallets/integration-guide/react/captcha.mdx
+++ b/solutions/embedded-wallets/integration-guide/react/captcha.mdx
@@ -2,7 +2,6 @@
 title: "Captcha"
 description: "Cloudflare Turnstile captcha protection in @turnkey/react-wallet-kit, handled automatically once enabled in the Dashboard."
 sidebarTitle: "Captcha"
-tag: "Early Access"
 ---
 
 ## Overview

--- a/solutions/embedded-wallets/integration-guide/typescript/captcha.mdx
+++ b/solutions/embedded-wallets/integration-guide/typescript/captcha.mdx
@@ -2,7 +2,6 @@
 title: "Captcha"
 description: "Add Cloudflare Turnstile captcha protection to your auth flows when building your own UI with @turnkey/core."
 sidebarTitle: "Captcha"
-tag: "Early Access"
 ---
 
 import CaptchaCoreBasics from "/snippets/shared/captcha-core-basics.mdx";


### PR DESCRIPTION
Refresh of the captcha docs ahead of GA. Copy revisions on the main captcha page, a new end-user Turnstile screenshot near the top, a replacement Dashboard screenshot to reflect the current experience, and removal of the Early Access tags across all captcha pages.

## Copy changes on `features/authentication/captcha.mdx`

- Meta description reworded (drops the awkward "Turnstile Captcha" phrasing).
- Sub-org entry-point bullet reworded to "Signing up a new user" for reader clarity, keeping the technically precise "new sub-org" reference.
- Verification-token paragraph rewritten to lead with the rule ("challenged once per flow") rather than the mechanism, and to name "returning users" instead of "existing-account logins".
- New `<Warning>` at the top of the enablement section calling out the SDK version floor:
  > **SDK version requirement:** Captcha support is only available in `@turnkey/react-wallet-kit` v2.4.0 and above. Enabling captcha before updating your SDK will break authentication for your users.
- The previous "automatic enforcement vs. DIY on `@turnkey/core`" content moved to a `<Note>` (it's useful context but not a warning-level risk).
- "Changes take effect immediately" note rewritten to explain the actual blast radius: server-side toggle flips instantly, older SDKs on protected flows (sign-ups, OTP sends) will break.

## Screenshots

- New end-user Turnstile widget screenshot inserted near the top of the main page so readers can immediately see what their users will see.
- Existing Dashboard screenshot swapped to a repo-relative `img src` path so a follow-up commit with the updated PNG will render.

**Images to add in a follow-up commit:**
- `images/authentication/img/captcha-end-user-widget.png` (new)
- `images/authentication/img/captcha-dashboard-toggle.png` (replacement)

## Early Access tag removal

Captcha is moving out of Early Access. Removed the `tag: "Early Access"` frontmatter from:

- `features/authentication/captcha.mdx`
- `solutions/embedded-wallets/integration-guide/react/captcha.mdx`
- `solutions/embedded-wallets/integration-guide/react-native/authentication/captcha.mdx`
- `solutions/embedded-wallets/integration-guide/typescript/captcha.mdx`

And trimmed the Early Access framing from the shared `snippets/shared/captcha-core-basics.mdx` note (kept the per-org gating context — still accurate and useful).

## Not touched

`docs.json` requires no change — the sidebar pills on captcha entries are driven by the per-page frontmatter tags removed above. The two Early Access tag entries in `docs.json` belong to Earn and Swaps.
