### PR TITLE
updated instructions to highly prioritize BugCrowd

### DIFF
--- a/security/reporting-a-vulnerability.mdx
+++ b/security/reporting-a-vulnerability.mdx
@@ -2,19 +2,7 @@
 title: "Reporting a vulnerability"
 ---
 
-Turnkey highly values the security of our software, services, and systems and we actively encourage the ethical reporting of any security vulnerabilities discovered. We invite researchers and users to report potential security vulnerabilities to our Bug Bounty Program via the form below, which is our preferred path for vulnerability reports.  Alternatively, you may email us at [security@turnkey.com](mailto:security@turnkey.com). When submitting a report, please provide a thorough description of the vulnerability, including steps to reproduce it and its potential impact.
-
-If you believe you have found very serious vulnerability, we ask that you encrypt the message to the `security.turnkey.com` PGP key (FP: `AD6C 3E61 17A5 886E 550E F8BB 3ACD E5EA 8DC7 9275`). This can also be found on Turnkey's website at https://www.turnkey.com/.well-known/security.asc.txt
-
-Upon receiving a report, our team promptly assesses and prioritizes the vulnerability based on its severity and potential impact. We then take reasonable and appropriate steps to mitigate and remediate the identified risks in accordance with our internal policies and timelines. Where feasible, we will endeavor to keep the reporter informed throughout the process. Our approach is designed to ensure confidentiality and offer safe harbor to researchers, promising that those who report vulnerabilities ethically and in good faith will not face legal action. Turnkey offers monetary rewards of up to $50,000 for valid reports, determining the rewarded amount based on the severity of the vulnerability.
-
-We expect reporters to treat vulnerability reports submitted to Turnkey, along with all associated information and/or data, with a high degree of care, use it solely for the purpose of reporting to Turnkey, and to not disclose it to any third parties without our written consent. With the reporter's consent, we may publicly disclose details of the vulnerability and acknowledge their contribution after it has been resolved.
-
-For further inquiries or more information about our program, please contact our security team at [security@turnkey.com](mailto:security@turnkey.com).
-
-## Bug bounty submissions
-
-Use the form below to directly submit vulnerabilities for triage and evaluation as part of our bug bounty program.
+Turnkey highly values the security of our software, services, and systems and we actively encourage the ethical reporting of any security vulnerabilities discovered. We invite researchers and users to report potential security vulnerabilities to our Bug Bounty Program via this form. When submitting a report, please provide a thorough description of the vulnerability, including steps to reproduce it and its potential impact. If you believe you have found very serious vulnerability, we ask that you encrypt the message to the `security.turnkey.com` PGP key (FP: `AD6C 3E61 17A5 886E 550E F8BB 3ACD E5EA 8DC7 9275`). This can also be found on Turnkey's website at https://www.turnkey.com/.well-known/security.asc.txt
 
 <iframe
   allow="clipboard-read; clipboard-write"
@@ -26,3 +14,13 @@ Use the form below to directly submit vulnerabilities for triage and evaluation 
   width="100%"
   height="2500px"
 />
+
+
+Upon receiving a report, our team promptly assesses and prioritizes the vulnerability based on its severity and potential impact. We then take reasonable and appropriate steps to mitigate and remediate the identified risks in accordance with our internal policies and timelines. Where feasible, we will endeavor to keep the reporter informed throughout the process. Our approach is designed to ensure confidentiality and offer safe harbor to researchers, promising that those who report vulnerabilities ethically and in good faith will not face legal action. Turnkey offers monetary rewards of up to $50,000 for valid reports, determining the rewarded amount based on the severity of the vulnerability.
+
+We expect reporters to treat vulnerability reports submitted to Turnkey, along with all associated information and/or data, with a high degree of care, use it solely for the purpose of reporting to Turnkey, and to not disclose it to any third parties without our written consent. With the reporter's consent, we may publicly disclose details of the vulnerability and acknowledge their contribution after it has been resolved.
+
+For further inquiries or more information about our program, please contact our security team at [security@turnkey.com](mailto:security@turnkey.com).
+
+
+


### PR DESCRIPTION
This change is to emphasize the bug bounty path for reporting vulnerabilities rather than the security email address