### PR TITLE
Fix MFA recovery: deprecated activity + invalid scope expression

### DIFF
--- a/features/authentication/mfa/enforcement-and-recovery.mdx
+++ b/features/authentication/mfa/enforcement-and-recovery.mdx
@@ -73,7 +73,7 @@ sensitive actions until the user logs in again with the newly recovered passkey.
 1. User initiates recovery, providing their email address.
 2. User satisfies a conditional MFA policy: email OTP + SMS OTP (or email OTP + OAuth).
 3. Upon successful MFA, user receives a recovery-scoped session token.
-4. User enrolls a new passkey using the `ACTIVITY_TYPE_RECOVER_USER` activity.
+4. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity.
 5. User logs in normally with the new passkey to access their account.
 
 #### Design rationale
@@ -89,7 +89,7 @@ First, create a session profile that permits only credential registration:
 ```json
 {
   "sessionProfileName": "recovery-authenticator-only",
-  "scope": "activity.resource == 'AUTHENTICATOR' && activity.action == 'CREATE'",
+  "scope": "activity.kind == 'CREATE_AUTHENTICATORS'",
   "expirationSeconds": 600
 }
 ```
@@ -124,7 +124,8 @@ mfaPolicy: {
 ```
 
 Once the user obtains the recovery-scoped session, they call
-[RECOVER_USER](/api-reference/activities/recover-a-user) to register a new passkey.
+[CREATE_AUTHENTICATORS_V2](/api-reference/activities/create-authenticators) to register a new
+passkey.
 
 The user can now use this freshly registered passkey for normal login.
 

--- a/features/authentication/mfa/enforcement-and-recovery.mdx
+++ b/features/authentication/mfa/enforcement-and-recovery.mdx
@@ -70,11 +70,17 @@ sensitive actions until the user logs in again with the newly recovered passkey.
 
 #### How it works
 
-1. User initiates recovery, providing their email address.
-2. User satisfies a conditional MFA policy: email OTP + SMS OTP (or email OTP + OAuth).
-3. Upon successful MFA, user receives a recovery-scoped session token.
-4. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity.
-5. User logs in normally with the new passkey to access their account.
+1. Ahead of time, you create a session profile scoped to authenticator enrollment only, plus a
+   conditional MFA policy that applies to logins targeting that profile.
+2. User initiates recovery, providing their email address.
+3. Your backend begins an OTP login, passing the recovery profile's `sessionProfileId` on the login
+   activity. This is what makes the resulting session scoped.
+4. User satisfies the conditional MFA policy: email OTP + SMS OTP (or email OTP + OAuth).
+5. On success, the login returns a session token bound to that profile. It can enroll a credential
+   and nothing else — it cannot sign, export, or move funds.
+6. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity, stamped with the
+   recovery session.
+7. User logs in normally with the new passkey to access their account.
 
 #### Design rationale
 


### PR DESCRIPTION
Fixes two errors in the MFA recovery guidance page (merged in #795):

## Changes

1. **Replace `RECOVER_USER` with `CREATE_AUTHENTICATORS_V2`** — `RECOVER_USER` is a legacy/deprecated activity. The current recommended activity for enrolling authenticators during recovery is `CREATE_AUTHENTICATORS_V2`.

2. **Fix session profile scope expression** — The original scope `activity.resource == 'AUTHENTICATOR' && activity.action == 'CREATE'` is invalid. The resource name `'AUTHENTICATOR'` doesn't exist in the policy language.

   **Correct expression:** `activity.kind == 'CREATE_AUTHENTICATORS'`

   This is version-agnostic (matches both V1 and V2 of the activity), narrow (only authenticator creation, not API keys or OAuth providers), and aligns with the policy language docs' recommendation to prefer `activity.kind` over `activity.type` for version-agnostic policies.

## Impact

The session profile JSON example in the "Recovery through new authenticator enrollment" section now uses verified, working syntax. Customers copying the example will get a valid session profile instead of a runtime error.

## Verification

Both fixes confirmed against:
- `/features/policies/language` (policy language reference)
- `/api-reference/activities/create-authenticators` (CREATE_AUTHENTICATORS_V2 API docs)
