### PR TITLE
docs(security): add Trust Center page under Security Resources with S…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1069,6 +1069,7 @@
               "security/turnkey-verified",
               "security/disaster-recovery",
               "security/whitepaper",
+              "security/trust-center",
               "security/reporting-a-vulnerability"
             ]
           }

--- a/security/overview.mdx
+++ b/security/overview.mdx
@@ -27,4 +27,5 @@ holistic security model in-depth, and speaks to our vision for building verifiab
   <FeatureCard title="Shared responsibility model" icon="intersect-circle" href="/security/shared-responsibility-model" description="Which security responsibilities are Turnkey's and which are yours as an integrator." />
   <FeatureCard title="Remote attestation" icon="check-circle" href="/security/remote-attestation" description="How Turnkey enclaves cryptographically prove their identity and integrity to a remote verifier." />
   <FeatureCard title="Turnkey Verified" icon="file-shield-02" href="/security/turnkey-verified" description="Cryptographic verification that only authorized code is running in Turnkey's secure enclaves." />
+  <FeatureCard title="Trust Center" icon="check-circle" href="/security/trust-center" description="Turnkey's security and compliance posture: certifications, controls, and subprocessors." />
 </div>

--- a/security/trust-center.mdx
+++ b/security/trust-center.mdx
@@ -1,0 +1,25 @@
+---
+title: "Trust Center"
+description: "Turnkey's security and compliance posture, certifications, controls, and subprocessors, all in one place."
+---
+
+Turnkey's [Trust Center](https://trust.turnkey.com/) is the home for our
+security and compliance posture. It covers:
+
+- **Compliance**: our SOC 2 Type II and GDPR compliance.
+- **Controls**: the security controls we maintain across infrastructure,
+  organizational, and product security, internal security procedures, and data
+  and privacy.
+- **Subprocessors**: the third-party services we rely on and where they process
+  data.
+- **Security FAQ**: answers to common questions, such as how Turnkey is
+  non-custodial, how users are authenticated, and where data is processed and
+  stored.
+- **Resources**: our security architecture, [the Turnkey
+  whitepaper](/security/whitepaper), the
+  [QuorumOS source](https://github.com/tkhq/qos),
+  [Turnkey Verified](/security/turnkey-verified), and our
+  [vulnerability disclosure program](/security/reporting-a-vulnerability).
+
+For anything the Trust Center does not answer, reach the security team directly
+at [security@turnkey.com](mailto:security@turnkey.com).

--- a/solutions/support/overview.mdx
+++ b/solutions/support/overview.mdx
@@ -179,4 +179,7 @@ Many questions are answered in the docs:
 - [SDK reference](/sdks/introduction) and the
   [example apps](https://github.com/tkhq/sdk/tree/main/examples) in the Turnkey
   SDK repository include working integrations you can compare against.
+- The [Trust Center](https://trust.turnkey.com/) has our security and
+  compliance resources, including compliance status, security controls, and
+  subprocessors.
 


### PR DESCRIPTION
# What

Add Trust Center to docs.

- adds a Trust Center page to the Security docs that points to https://trust.turnkey.com/
- adds a feature card to the Security overview page that points to the new Trust center doc page
- adds a pointer to the Trust Center from the Support doc

# Ticket

Closes [CUS-310](https://linear.app/turnkey/issue/CUS-310/add-trust-center-link-to-docs-support-doc)