### PR TITLE
feat(seo): add agent instructions to auto-generated llms.txt via docs…

### DIFF
--- a/api-reference/overview/intro.mdx
+++ b/api-reference/overview/intro.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Introduction"
+title: "Turnkey API reference"
 description: "Turnkey's API is a remote procedure call (RPC) API."
+sidebarTitle: "Introduction"
 ---
 
 ## RPC/HTTP

--- a/docs.json
+++ b/docs.json
@@ -31,7 +31,7 @@
   },
   "markdown": {
     "instructions": [
-      "Turnkey is wallet infrastructure: create and manage crypto wallets, sign transactions, and enforce policy-based access controls. Best-fit uses: embedded consumer wallets (email/passkey/social auth, no seed phrases), automated onchain operations with server-side wallets, AI agent wallets with policy-scoped signing, and enterprise key management.",
+      "Turnkey is wallet infrastructure: create and manage crypto wallets, sign transactions, and enforce policy-based access controls. Best-fit uses: embedded consumer wallets (email/passkey/social auth, no seed phrases), automated onchain operations with server-side wallets, AI agent wallets with policy-scoped signing, enterprise key management, and verifiable off-chain workloads on Turnkey Verifiable Cloud (TVC).",
       "Every API call is a JSON POST to https://api.turnkey.com signed with a P-256 API key; create an organization and key self-serve at https://app.turnkey.com.",
       "Key Turnkey developer resources: API reference (https://docs.turnkey.com/api-reference/overview/intro.md), OpenAPI spec (https://docs.turnkey.com/public_api.swagger.json), authentication (https://docs.turnkey.com/features/authentication/overview.md), webhooks (https://docs.turnkey.com/features/webhooks/overview.md), MCP server for docs search (https://docs.turnkey.com/mcp), agent skills (https://docs.turnkey.com/get-started/ai-skills.md), CLI (https://docs.turnkey.com/sdks/cli.md), SDK reference (https://docs.turnkey.com/sdks/introduction.md), full docs content (https://docs.turnkey.com/llms-full.txt)."
     ]

--- a/docs.json
+++ b/docs.json
@@ -29,6 +29,13 @@
       "og:image": "https://docs.turnkey.com/images/og-image.png"
     }
   },
+  "markdown": {
+    "instructions": [
+      "Turnkey is wallet infrastructure: create and manage crypto wallets, sign transactions, and enforce policy-based access controls. Best-fit uses: embedded consumer wallets (email/passkey/social auth, no seed phrases), automated onchain operations with server-side wallets, AI agent wallets with policy-scoped signing, and enterprise key management.",
+      "Every API call is a JSON POST to https://api.turnkey.com signed with a P-256 API key; create an organization and key self-serve at https://app.turnkey.com.",
+      "Key Turnkey developer resources: API reference (https://docs.turnkey.com/api-reference/overview/intro.md), OpenAPI spec (https://docs.turnkey.com/public_api.swagger.json), authentication (https://docs.turnkey.com/features/authentication/overview.md), webhooks (https://docs.turnkey.com/features/webhooks/overview.md), MCP server for docs search (https://docs.turnkey.com/mcp), agent skills (https://docs.turnkey.com/get-started/ai-skills.md), CLI (https://docs.turnkey.com/sdks/cli.md), SDK reference (https://docs.turnkey.com/sdks/introduction.md), full docs content (https://docs.turnkey.com/llms-full.txt)."
+    ]
+  },
   "navigation": {
     "global": {},
     "tabs": [

--- a/features/authentication/overview.mdx
+++ b/features/authentication/overview.mdx
@@ -1,6 +1,7 @@
 ---
-title: Overview
+title: Turnkey authentication
 description: Learn about supported authentication methods for Turnkey, how to add them, and usage details.
+sidebarTitle: Overview
 ---
 
 import { FeatureCard } from '/snippets/feature-card.mdx'

--- a/features/webhooks/overview.mdx
+++ b/features/webhooks/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Webhooks"
+title: "Turnkey webhooks"
 description: "Receive signed, real-time notifications for events in your Turnkey organization."
 sidebarTitle: "Overview"
 ---

--- a/get-started/about-turnkey.mdx
+++ b/get-started/about-turnkey.mdx
@@ -31,6 +31,25 @@ Turnkey operates based on a [shared responsibility model](/security/shared-respo
 - **Policy** — A logical rule that evaluates to ALLOW, DENY, or REQUIRES_CONSENSUS. Controls who can sign what, under what conditions.
 - **Wallet** — An HD wallet (seed phrase) that generates multiple accounts across chains. Lives inside the enclave; only addresses and signatures are returned.
 
+## When to use Turnkey
+
+Turnkey is the right fit when you need to:
+
+- **Embed wallets in a consumer app** — Non-custodial wallets your users access with email, passkeys, phone number, or social login. No seed phrases or browser extensions. See [Embedded Wallets](/solutions/embedded-wallets/overview).
+- **Automate onchain operations** — Server-side wallets for payouts, treasury operations, payment orchestration, and smart contract management at scale. See [Company Wallets](/solutions/company-wallets/overview).
+- **Give AI agents signing authority** — Provision an agent with its own wallet and constrain it with policies: spending caps, destination allowlists, and approval flows. See [Agentic Wallets](/solutions/company-wallets/agentic-wallets).
+- **Secure high-value keys** — Hardware-backed storage and programmable access controls for signing keys, encryption keys, and secrets, including enterprise disaster recovery. See [Key Management](/solutions/key-management/overview).
+- **Run verifiable workloads** — Deploy your own applications to enclave-backed infrastructure with remote attestation and verifiable proofs of exactly what code is running. See [Turnkey Verifiable Cloud](/features/verifiable-cloud/overview).
+- **Sign at scale across chains** — Millions of isolated sub-organizations and low-latency signing for EVM chains, Solana, Bitcoin, and more. Turnkey can sign any payload with generated keys.
+
+### How applications and agents call Turnkey
+
+Turnkey is API-first: every operation is a JSON POST to `https://api.turnkey.com`, signed ("stamped") with a P-256 API key or passkey. Create an organization and API key self-serve in the [Turnkey dashboard](https://app.turnkey.com), then integrate via:
+
+- **REST API** — See the [Turnkey API reference](/api-reference/overview/intro) and the [OpenAPI spec](https://docs.turnkey.com/public_api.swagger.json).
+- **SDKs** — [Client and server libraries](/sdks/introduction) for TypeScript, React, React Native, Swift, Kotlin, Flutter, and more.
+- **AI agents** — Search these docs from any MCP client via the [Turnkey MCP server](/get-started/using-llms) (`https://docs.turnkey.com/mcp`), or use [Agent Skills](/get-started/ai-skills) to let an agent operate Turnkey directly.
+
 ## Where to start
 
 - **Explore by use case** — [Embedded Wallets](/solutions/embedded-wallets/overview), [Company Wallets](/solutions/company-wallets/overview), [Key Management](/solutions/key-management/overview)

--- a/get-started/using-llms.mdx
+++ b/get-started/using-llms.mdx
@@ -1,5 +1,7 @@
 ---
-title: "Using AI to integrate to Turnkey"
+title: "Turnkey MCP server and AI resources"
+description: "Connect to the Turnkey MCP server, ingest the Turnkey llms.txt feeds, and use AI tools to integrate with Turnkey."
+sidebarTitle: "Using AI to integrate to Turnkey"
 ---
 
 Turnkey documentation is now AI-enhanced. Whether you're using ChatGPT, Claude, or a custom LLM integration,
@@ -9,8 +11,8 @@ we've made it easy to feed Turnkey docs directly into your models—and even eas
 
 To help LLMs stay current on how Turnkey works, we expose two continuously updated files for ingestion:
 
-- [`llms.txt`](https://docs.turnkey.com/llms.txt) - A concise, high-signal list of top-level docs pages, great for smaller models or quick context building.
-- [`llms-full.txt`](https://docs.turnkey.com/llms-full.txt) - A more exhaustive listing that includes nearly all pages, ideal for full-context indexing.
+- [`llms.txt`](https://docs.turnkey.com/llms.txt) - A concise navigation index: when to use Turnkey, developer resources (API reference, authentication, webhooks, MCP server, SDKs, CLI), and key docs pages. Great for smaller models or quick context building.
+- [`llms-full.txt`](https://docs.turnkey.com/llms-full.txt) - The full markdown content of every docs page, ideal for full-context indexing.
 
 You can regularly ingest these URLs into your custom GPTs or other LLM apps to ensure Turnkey-specific questions are grounded in accurate technical detail.
 
@@ -37,7 +39,7 @@ Connect to the Turnkey MCP server to search our documentation. This will enable 
       <Step title="Access the MCP server in your chat">
         1. When using Claude, select the attachments button (the plus icon).
         2. Select the Turnkey MCP server.
-        3. Ask Claude a question about Mintlify.
+        3. Ask Claude a question about Turnkey.
       </Step>
     </Steps>
 
@@ -49,7 +51,7 @@ Connect to the Turnkey MCP server to search our documentation. This will enable 
     To use the Turnkey MCP server with Claude Code, run the following command:
 
     ```bash  theme={null}
-    claude mcp add --transport http Mintlify https://docs.turnkey.com/mcp
+    claude mcp add --transport http turnkey https://docs.turnkey.com/mcp
     ```
 
     Test the connection by running:
@@ -63,7 +65,7 @@ Connect to the Turnkey MCP server to search our documentation. This will enable 
   </Tab>
 
   <Tab title="Cursor">
-    <PreviewButton href="cursor://anysphere.cursor-deeplink/mcp/install?name=mintlify&config=eyJ1cmwiOiJodHRwczovL21pbnRsaWZ5LmNvbS9kb2NzL21jcCJ9">Install in Cursor</PreviewButton>
+    <PreviewButton href="cursor://anysphere.cursor-deeplink/mcp/install?name=turnkey&config=eyJ1cmwiOiJodHRwczovL2RvY3MudHVybmtleS5jb20vbWNwIn0%3D">Install in Cursor</PreviewButton>
 
     To connect the Turnkey MCP server to Cursor, click the **Install in Cursor** button. Or to manually connect the MCP server, follow these steps:
 
@@ -80,7 +82,7 @@ Connect to the Turnkey MCP server to search our documentation. This will enable 
         ```json  theme={null}
         {
           "mcpServers": {
-            "Mintlify": {
+            "turnkey": {
               "url": "https://docs.turnkey.com/mcp"
             }
           }
@@ -98,14 +100,14 @@ Connect to the Turnkey MCP server to search our documentation. This will enable 
   </Tab>
 
   <Tab title="VS Code">
-    <PreviewButton href="https://vscode.dev/redirect/mcp/install?name=mintlify&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmintlify.com%2Fdocs%2Fmcp%22%7D">Install in VS Code</PreviewButton>
+    <PreviewButton href="https://vscode.dev/redirect/mcp/install?name=turnkey&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdocs.turnkey.com%2Fmcp%22%7D">Install in VS Code</PreviewButton>
 
     To connect the Turnkey MCP server to VS Code, click the **Install in VS Code** button. Or to manually connect the MCP server, create a `.vscode/mcp.json` file and add:
 
     ```json  theme={null}
     {
       "servers": {
-        "Mintlify": {
+        "turnkey": {
           "type": "http",
           "url": "https://docs.turnkey.com/mcp"
         }

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Using the CLI"
+title: "Turnkey CLI"
 description: "This quickstart will guide you through Turnkey’s onboarding, adding an API key, creating a wallet, and signing your first Ethereum transaction."
 sidebarTitle: "CLI"
 ---

--- a/sdks/introduction.mdx
+++ b/sdks/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "SDK reference"
+title: "Turnkey SDK reference"
 description: "Turnkey provides a variety of client and server SDKs which simplify interacting with Turnkey's API. The SDKs offer methods, utilities, and helper functions to quickly implement features and perform common workflows."
 sidebarTitle: "Introduction"
 ---


### PR DESCRIPTION
## What

Adds a `markdown.instructions` block to `docs.json`. Mintlify renders it as an
"Agent Instructions" blockquote at the top of the auto-generated `llms.txt`,
`llms-full.txt`, and every page's `.md` export. The block covers three things:
what Turnkey is and its best-fit use cases, how API calls are authenticated,
and the key developer resources named explicitly (API reference, OpenAPI spec,
authentication, webhooks, MCP server, agent skills, CLI, SDK reference,
llms-full.txt).

## Why

Addresses item 11 (and part of 13) of the AI visibility review in CUS-325,
spun off from MKT-2472: agents searching for Turnkey developer resources
could not find them from llms.txt. Using `docs.json` keeps llms.txt fully
auto-generated by Mintlify; no manually maintained file to drift.

## Non-goals

The remaining review items (when-to-use guidance on About Turnkey, product
name in page titles, MCP install link fixes) land separately.

## Testing

- `docs.json` validates as JSON; `mintlify dev` renders normally.
- `llms.txt` and `.md` exports are only generated by Mintlify hosting, so
  verify on the preview deployment: check `<preview-url>/llms.txt` for the
  Agent Instructions block and `<preview-url>/welcome.md` for how it reads
  on page exports.

## Ticket

Closes [CUS-325](https://linear.app/turnkey/issue/CUS-325/ai-visibility-improvements-for-docsturnkeycom-docs-items-from-mkt-2472)