### PR TITLE
docs: remove remaining time-policy beta labels

### DIFF
--- a/features/policies/examples/time-based-policies.mdx
+++ b/features/policies/examples/time-based-policies.mdx
@@ -2,12 +2,7 @@
 title: "Time-based policies"
 description: "This page provides examples of policies that use the top-level `time` field to control when a policy is active."
 sidebarTitle: "Time-based policies"
-tag: "Beta"
 ---
-
-import { TimeBasedPoliciesBetaCallout } from "/snippets/time-based-policies-beta-callout.mdx";
-
-<TimeBasedPoliciesBetaCallout />
 
 The optional top-level `time` field controls when a policy is active. Like `consensus` and
 `condition`, it is written in the policy language and must evaluate to a `bool`. When `time` is not

--- a/features/policies/language.mdx
+++ b/features/policies/language.mdx
@@ -7,8 +7,6 @@ sidebarTitle: "Language"
 mode: "wide"
 ---
 
-import { TimeBasedPoliciesBetaCallout } from "/snippets/time-based-policies-beta-callout.mdx";
-
 <div className="policy-language">
 
 ## Grammar
@@ -65,8 +63,6 @@ Each field supports a different set of keywords.
 | **wallet_account**             | [WalletAccount](#struct-wallet-account)        | The target wallet account used in sign + export requests                    |
 
 ### Time
-
-<TimeBasedPoliciesBetaCallout />
 
 | Keyword      | Type      | Description                                                                                    |
 | ------------ | --------- | ---------------------------------------------------------------------------------------------- |
@@ -258,8 +254,6 @@ The language is strongly typed which makes policies easy to author and maintain.
 |                                 | function_signature      | [string](#type-string)                                | The 4-byte function selector derived from the call input (e.g. `0xa9059cbb` for ERC-20 `transfer`). Empty string when input is absent or too short                                                                                                         |
 
 ## Time expressions
-
-<TimeBasedPoliciesBetaCallout />
 
 Two functions are available when authoring the top-level `time` field. This section is the reference
 for their signatures and constraints; see

--- a/features/policies/time-based-policies.mdx
+++ b/features/policies/time-based-policies.mdx
@@ -4,8 +4,6 @@ description: "This page provides an overview of the Policy Engine's top-level `t
 sidebarTitle: "Time-based policies"
 ---
 
-import { TimeBasedPoliciesBetaCallout } from "/snippets/time-based-policies-beta-callout.mdx";
-
 ## Gating when a policy is active
 
 Turnkey policies support a top-level `time` field alongside `consensus` and `condition`. While `consensus` defines **who** and `condition` defines **what**, the `time` field defines **when** a policy is active.

--- a/snippets/time-based-policies-beta-callout.mdx
+++ b/snippets/time-based-policies-beta-callout.mdx
@@ -1,8 +1,0 @@
-export const TimeBasedPoliciesBetaCallout = () => (
-  <Warning>
-    Time-based policies are currently in Early Access and are gated behind a feature
-    flag. The top-level <code>time</code> field is rejected until the flag is
-    enabled for your organization. Reach out to the Turnkey team — or your
-    dedicated Slack channel, if you have one — to request access.
-  </Warning>
-);


### PR DESCRIPTION
## Summary

- remove the remaining Beta sidebar tag and Early Access callout from the time-based policy examples
- remove the Early Access callouts from the policy language reference and the stale import from the overview
- delete the now-unused shared callout snippet

Follow-up to #804.

## Validation

- `git diff --check origin/main...HEAD`
- verified no time-policy Beta/Early Access tags, callouts, or snippet references remain