### PR TITLE
MFA clarifications 

### DIFF
--- a/features/authentication/mfa/enforcement-and-recovery.mdx
+++ b/features/authentication/mfa/enforcement-and-recovery.mdx
@@ -73,20 +73,40 @@ sensitive actions until the user logs in again with the newly recovered passkey.
 1. Ahead of time, you create a session profile scoped to authenticator enrollment only, plus a
    conditional MFA policy that applies to logins targeting that profile.
 2. User initiates recovery, providing their email address.
-3. Your backend begins an OTP login, passing the recovery profile's `sessionProfileId` on the login
-   activity. This is what makes the resulting session scoped.
-4. User satisfies the conditional MFA policy: email OTP + SMS OTP (or email OTP + OAuth).
-5. On success, the login returns a session token bound to that profile. It can enroll a credential
-   and nothing else — it cannot sign, export, or move funds.
-6. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity, stamped with the
+3. Your backend runs `INIT_OTP` and `VERIFY_OTP`, then hands the verification token to the
+   browser.
+4. **The browser stamps the login**, passing the recovery profile's `sessionProfileId`. Naming
+   the profile is what makes the resulting session scoped, and stamping client-side is what
+   makes the login belong to the end user, so their MFA policy is the one evaluated. A login
+   stamped by your backend with a parent-organization API key would not be: see
+   [who stamped](./overview#mfa-is-evaluated-for-the-user-who-stamped).
+5. The login stops at `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED`, since the stamp presents only
+   the email OTP. The user satisfies the remaining factor, SMS OTP or OAuth, by
+   [approving the activity](./satisfying-mfa#email-otp-sms-otp-and-oauth) with a second
+   attested stamp.
+6. On success, the login returns a session token bound to that profile. It can enroll a
+   credential and nothing else — it cannot sign, export, or move funds.
+7. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity, stamped with the
    recovery session.
-7. User logs in normally with the new passkey to access their account.
+8. User logs in normally with the new passkey to access their account.
+
+<Warning>
+  The second factor has to be something the login stamp does not already carry. A recovery
+  policy requiring only an email OTP is satisfied the moment the request arrives, so no
+  challenge is raised and recovery is exactly as strong as the inbox.
+</Warning>
 
 #### Design rationale
 
-The recovery session profile acts as a strong mitigation. Even if an attacker successfully
-compromises both recovery factors (email and phone), they can only register a credential. They
-cannot immediately use that credential to drain the account or transfer assets.
+The recovery session profile limits the blast radius. An attacker who compromises both recovery
+factors cannot sign or export from the recovery session itself: they can only register a
+credential, and must then log in again with it, which is a second and separately observable
+step.
+
+Treat that as delay and detection rather than as a boundary, because the credential they enroll
+is an ordinary one. The real protection is that recovery demands two independent factors, so it
+is no weaker than the primary login, plus notifying on enrollment and holding withdrawals
+afterwards.
 
 #### Implementation example:
 

--- a/features/authentication/mfa/enforcement-and-recovery.mdx
+++ b/features/authentication/mfa/enforcement-and-recovery.mdx
@@ -71,7 +71,9 @@ sensitive actions until the user logs in again with the newly recovered passkey.
 #### How it works
 
 1. Ahead of time, you create a session profile scoped to authenticator enrollment only, plus a
-   conditional MFA policy that applies to logins targeting that profile.
+   conditional MFA policy that applies to logins targeting that profile. Give that policy two
+   steps, email OTP and then SMS OTP or OAuth, so that recovery is no weaker than the login it
+   replaces.
 2. User initiates recovery, providing their email address.
 3. Your backend runs `INIT_OTP` and `VERIFY_OTP`, then hands the verification token to the
    browser.
@@ -80,21 +82,19 @@ sensitive actions until the user logs in again with the newly recovered passkey.
    makes the login belong to the end user, so their MFA policy is the one evaluated. A login
    stamped by your backend with a parent-organization API key would not be: see
    [who stamped](./overview#mfa-is-evaluated-for-the-user-who-stamped).
-5. The login stops at `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED`, since the stamp presents only
-   the email OTP. The user satisfies the remaining factor, SMS OTP or OAuth, by
-   [approving the activity](./satisfying-mfa#email-otp-sms-otp-and-oauth) with a second
-   attested stamp.
-6. On success, the login returns a session token bound to that profile. It can enroll a
-   credential and nothing else — it cannot sign, export, or move funds.
-7. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity, stamped with the
+5. The login does not complete yet. The email OTP counts as the first factor, because the login
+   stamp carried it, and the MFA policy requires a second one. The response comes back with
+   status `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED` and the activity's `fingerprint`.
+6. The user completes the second factor, SMS OTP or OAuth. That produces a new token, which the
+   browser turns into a fresh attested stamp and uses to submit `APPROVE_ACTIVITY` for the
+   `fingerprint` from the previous step. See
+   [satisfying MFA](./satisfying-mfa#email-otp-sms-otp-and-oauth).
+7. Both factors are now satisfied, so the login completes and returns a session token bound to
+   the recovery profile. That session can enroll a credential and nothing else. It cannot sign,
+   export, or move funds.
+8. User enrolls a new passkey using the `CREATE_AUTHENTICATORS_V2` activity, stamped with the
    recovery session.
-8. User logs in normally with the new passkey to access their account.
-
-<Warning>
-  The second factor has to be something the login stamp does not already carry. A recovery
-  policy requiring only an email OTP is satisfied the moment the request arrives, so no
-  challenge is raised and recovery is exactly as strong as the inbox.
-</Warning>
+9. User logs in normally with the new passkey to access their account.
 
 #### Design rationale
 

--- a/features/authentication/mfa/examples.mdx
+++ b/features/authentication/mfa/examples.mdx
@@ -448,6 +448,10 @@ policy: {
 }
 ```
 
+<Warning>
+  Give your protective policy `order: 0`, as the example below does. Only the first matching policy applies, and two policies on the same user cannot share an order, so nothing can be placed ahead of order 0. Leave it free and a credential that can create MFA policies could take it with a permissive policy, overriding yours without modifying or deleting it.
+</Warning>
+
 Then, the delegated access user (controlled by the parent org) creates an MFA policy for the sub-org root user:
 
 ``` ts

--- a/features/authentication/mfa/overview.mdx
+++ b/features/authentication/mfa/overview.mdx
@@ -17,16 +17,16 @@ Since every request is authenticated by a stamp, the stamp is also what decides 
 This matters most at login, where the two are easily different:
 
 - A login **stamped in the browser** by the end user, such as `STAMP_LOGIN` carrying an [attested stamp](./satisfying-mfa#email-otp-sms-otp-and-oauth) from an email OTP or an OIDC token, is attributed to the sub-organization user. Their MFA policies apply.
-- A login **stamped with a parent-organization API key**, which is what `OTP_LOGIN` and `OAUTH_LOGIN` submitted from your backend or through the Auth Proxy do, is attributed to that parent user. The sub-organization user's MFA policies are never consulted, and the login succeeds with no error.
+- A login **stamped with a parent-organization API key** is attributed to that parent user, even though the login itself targets the sub-organization. This is what happens when your backend submits `OTP_LOGIN` or `OAUTH_LOGIN` with its own API key, and what the Auth Proxy does. The sub-organization user's MFA policies are never consulted, and the login succeeds with no error.
+
+The second case is a normal, supported way to run authentication, and nothing is wrong with it until you add MFA. It is worth checking which one you are on before writing a policy, because a backend-driven login is easy to build without ever noticing that the stamp came from your infrastructure rather than from the user.
 
 So an `activity.resource == 'AUTH'` policy only takes effect if the login itself is stamped by the end user. If your login is backend-driven, keep `INIT_OTP` and `VERIFY_OTP` on your server and let the browser stamp the login with the verification token, which is bound to a client-generated key and useless to anyone else.
 
 ## MFA policies
 MFA policies are a unique resource type in Turnkey that allows configuration of authentication requirements, scoped to a specific condition.
 
-MFA policies can be configured in both parent and sub-organizations, and are enforced at the user level rather than the organization level.
-
-**MFA applies to root users.** This is the exception to the usual rule: a root user's activities bypass the policy engine, but MFA is evaluated before that happens, so an unsatisfied MFA policy stops a root user like anyone else. It is the only policy type that constrains them. Because policies attach to users rather than organizations, each root user needs their own, and a user added to the root quorum later has none until you create one.
+MFA policies can be configured in both parent and sub-organizations, and are enforced at the user level rather than the organization level. MFA applies to all users, including root users and non-root users.
 
 Once an MFA policy is created, it is immediately enforced for the user.
 
@@ -39,6 +39,10 @@ An MFA policy can be created using the `CreateMfaPolicy` activity and passing in
 - `requiredAuthenticationMethods`: An ordered list of authentication steps that must be satisfied when the policy condition is met. Each step contains an `any` array of acceptable methods. If multiple methods are listed in `any`, satisfying any one of them fulfills that step.
 - `order`: An integer that specifies the order of evaluation for multiple MFA policies. Policies with lower order values are evaluated first.
 - `notes`: Optional field for any additional information about the policy
+
+<Note>
+  When updating a policy with `UpdateMfaPolicy`, an empty `requiredAuthenticationMethods` array means "leave unchanged", not "remove". A policy always has at least one required method, so to relax a policy, send the methods you want rather than an empty array. To stop requiring MFA in a case, narrow the `condition` or delete the policy.
+</Note>
 
 ### Condition
 
@@ -95,17 +99,30 @@ In the example above, the user must:
 2. Authenticate with **either** a passkey **or** email OTP
 
 <Warning>
-  **Do not list the same method in two steps.** A credential is not used up by satisfying a step: each step is checked independently against everything the user has presented. So if a passkey can satisfy step 1, and the passkey is also listed in step 2, a single passkey satisfies both steps.
+  **Do not list the same method in more than one step.** Each step is checked independently against everything the user has presented, and satisfying a step does not use the credential up. A method listed in two steps therefore satisfies both.
+
+  Suppose you want to require any two of passkey and email OTP, and write this:
 
   ```json
-  // Two steps, but one passkey satisfies both. This is one factor, not two.
   "requiredAuthenticationMethods": [
     { "any": [{ "type": "AUTHENTICATION_TYPE_PASSKEY" }, { "type": "AUTHENTICATION_TYPE_EMAIL_OTP" }] },
     { "any": [{ "type": "AUTHENTICATION_TYPE_PASSKEY" }, { "type": "AUTHENTICATION_TYPE_EMAIL_OTP" }] }
   ]
   ```
 
-  To require two different factors, put one in each step, as the example above does. There is no way to express "any two of these three": every step you add must name the factors it accepts, and those sets must not overlap.
+  The user stamps with their passkey. Step 1 looks for a passkey or an email OTP and finds the passkey. Step 2 looks for the same two things and finds the same passkey. Both steps pass, no challenge is raised, and the activity proceeds on a single factor.
+
+  Listing several methods in one step is fine, and is how you let the user choose. The rule is only that no method may appear in more than one step:
+
+  ```json
+  // A passkey, plus either an email OTP or an SMS OTP
+  "requiredAuthenticationMethods": [
+    { "any": [{ "type": "AUTHENTICATION_TYPE_PASSKEY" }] },
+    { "any": [{ "type": "AUTHENTICATION_TYPE_EMAIL_OTP" }, { "type": "AUTHENTICATION_TYPE_SMS_OTP" }] }
+  ]
+  ```
+
+  This is also why "any two of these three" cannot be expressed. Every step must name the specific methods it accepts.
 </Warning>
 
 You can find more examples [here](./examples).
@@ -119,6 +136,19 @@ Each `AuthenticationMethodParams` accepts:
   - `AUTHENTICATION_TYPE_SMS_OTP`
   - `AUTHENTICATION_TYPE_OAUTH`
 - `id` (optional): A specific authentication method's ID. When provided, only that specific authentication method satisfies the requirement. When omitted, any authentication method of the specified type can be used. Note that Email OTP and SMS OTP do not have IDs.
+
+For `AUTHENTICATION_TYPE_SESSION`, the `id` is a [session profile](../sessions/session-profiles) ID, and the all-zero UUID is a special case that inverts the check: it requires a session with **no** profile attached, meaning an ordinary read/write session. Use it to exclude scoped sessions from an activity.
+
+```json
+// Signing requires a normal session, so a recovery-scoped session cannot satisfy it
+{
+  "condition": "activity.action == 'SIGN'",
+  "order": 0,
+  "requiredAuthenticationMethods": [
+    { "any": [{ "type": "AUTHENTICATION_TYPE_SESSION", "id": "00000000-0000-0000-0000-000000000000" }] }
+  ]
+}
+```
 
 #### The user must already be able to satisfy the policy
 

--- a/features/authentication/mfa/overview.mdx
+++ b/features/authentication/mfa/overview.mdx
@@ -10,10 +10,23 @@ Requests made to Turnkey's public API are required to be authenticated using [a 
 
 Turnkey's MFA policies can be configured to require any combination of supported authentication methods.
 
+## MFA is evaluated for the user who stamped
+
+Since every request is authenticated by a stamp, the stamp is also what decides **whose** MFA policies apply. Turnkey evaluates the policies of the user whose credential signed the request, not of the user the activity happens to be about.
+
+This matters most at login, where the two are easily different:
+
+- A login **stamped in the browser** by the end user, such as `STAMP_LOGIN` carrying an [attested stamp](./satisfying-mfa#email-otp-sms-otp-and-oauth) from an email OTP or an OIDC token, is attributed to the sub-organization user. Their MFA policies apply.
+- A login **stamped with a parent-organization API key**, which is what `OTP_LOGIN` and `OAUTH_LOGIN` submitted from your backend or through the Auth Proxy do, is attributed to that parent user. The sub-organization user's MFA policies are never consulted, and the login succeeds with no error.
+
+So an `activity.resource == 'AUTH'` policy only takes effect if the login itself is stamped by the end user. If your login is backend-driven, keep `INIT_OTP` and `VERIFY_OTP` on your server and let the browser stamp the login with the verification token, which is bound to a client-generated key and useless to anyone else.
+
 ## MFA policies
 MFA policies are a unique resource type in Turnkey that allows configuration of authentication requirements, scoped to a specific condition.
 
-MFA policies can be configured in both parent and sub-organizations, and are enforced at the user level rather than the organization level. MFA applies to all users, including root users and non-root users.
+MFA policies can be configured in both parent and sub-organizations, and are enforced at the user level rather than the organization level.
+
+**MFA applies to root users.** This is the exception to the usual rule: a root user's activities bypass the policy engine, but MFA is evaluated before that happens, so an unsatisfied MFA policy stops a root user like anyone else. It is the only policy type that constrains them. Because policies attach to users rather than organizations, each root user needs their own, and a user added to the root quorum later has none until you create one.
 
 Once an MFA policy is created, it is immediately enforced for the user.
 
@@ -81,6 +94,20 @@ In the example above, the user must:
 1. Authenticate with an API key
 2. Authenticate with **either** a passkey **or** email OTP
 
+<Warning>
+  **Do not list the same method in two steps.** A credential is not used up by satisfying a step: each step is checked independently against everything the user has presented. So if a passkey can satisfy step 1, and the passkey is also listed in step 2, a single passkey satisfies both steps.
+
+  ```json
+  // Two steps, but one passkey satisfies both. This is one factor, not two.
+  "requiredAuthenticationMethods": [
+    { "any": [{ "type": "AUTHENTICATION_TYPE_PASSKEY" }, { "type": "AUTHENTICATION_TYPE_EMAIL_OTP" }] },
+    { "any": [{ "type": "AUTHENTICATION_TYPE_PASSKEY" }, { "type": "AUTHENTICATION_TYPE_EMAIL_OTP" }] }
+  ]
+  ```
+
+  To require two different factors, put one in each step, as the example above does. There is no way to express "any two of these three": every step you add must name the factors it accepts, and those sets must not overlap.
+</Warning>
+
 You can find more examples [here](./examples).
 
 Each `AuthenticationMethodParams` accepts:
@@ -92,6 +119,28 @@ Each `AuthenticationMethodParams` accepts:
   - `AUTHENTICATION_TYPE_SMS_OTP`
   - `AUTHENTICATION_TYPE_OAUTH`
 - `id` (optional): A specific authentication method's ID. When provided, only that specific authentication method satisfies the requirement. When omitted, any authentication method of the specified type can be used. Note that Email OTP and SMS OTP do not have IDs.
+
+#### The user must already be able to satisfy the policy
+
+Turnkey rejects a policy the user has no way to meet, at creation time:
+
+```
+user (<user-id>) cannot satisfy mfa policy requirement: mfa policy '<name>'
+requires one of ["Passkey"] but user does not, or will not, have a matching credential
+```
+
+Each type is checked against what the user has today:
+
+| Type | Requires |
+| :--- | :--- |
+| `AUTHENTICATION_TYPE_PASSKEY` | an enrolled authenticator, or the specific one if you pinned an `id` |
+| `AUTHENTICATION_TYPE_API_KEY` | a long-lived API key |
+| `AUTHENTICATION_TYPE_EMAIL_OTP` | `userEmail` set |
+| `AUTHENTICATION_TYPE_SMS_OTP` | `userPhoneNumber` set |
+| `AUTHENTICATION_TYPE_OAUTH` | at least one linked OAuth provider |
+| `AUTHENTICATION_TYPE_SESSION` | nothing: a session is always obtainable. If you pin an `id`, that session profile must exist |
+
+So enroll the credential first, then create the policy. This also means you cannot lock a user out by writing a policy, only by removing a credential a policy already depends on.
 
 ### Evaluation order
 

--- a/features/authentication/mfa/satisfying-mfa.mdx
+++ b/features/authentication/mfa/satisfying-mfa.mdx
@@ -38,6 +38,8 @@ If the MFA policy specifies an `id` for a session authentication method, the `id
 
 Note that sessions are **not transitive**. For example, if a passkey was used to create a session, and an MFA policy requires `AUTHENTICATION_TYPE_PASSKEY`, the session **will not** satisfy that requirement. The user must stamp directly with the passkey.
 
+The same applies to logins that used an OTP or OAuth. A session obtained by signing in with Google presents as `AUTHENTICATION_TYPE_SESSION`, never `AUTHENTICATION_TYPE_OAUTH`, so a policy requiring OAuth sends the user back through the provider for a fresh OIDC token. Only an attested stamp presents `AUTHENTICATION_TYPE_OAUTH`, `AUTHENTICATION_TYPE_EMAIL_OTP` or `AUTHENTICATION_TYPE_SMS_OTP`.
+
 ## Email OTP, SMS OTP, and OAuth
 
 Unlike API keys and passkeys, OTP and OAuth authenticators cannot directly sign requests. Instead, they use [attested stamps](/api-reference/overview/stamps#attested), where a client-side key signs the request and a token (verification token or OIDC token) attests that the key belongs to the identity.
@@ -45,6 +47,35 @@ Unlike API keys and passkeys, OTP and OAuth authenticators cannot directly sign 
 To prove Email OTP, SMS OTP, or OAuth authentication, the user stamps the `APPROVE_ACTIVITY` request with an attested stamp.
 
 Only OAuth authenticators support the `id` field in MFA policies. If specified, the user must prove ownership of that specific OAuth provider identity. Email and SMS OTP authenticators do not have IDs.
+
+### Obtaining the attested stamp
+
+Both token types come from a flow the user completes in the browser, and both are bound to a key the client generates.
+
+Email or SMS OTP:
+
+```ts
+// verifyOtp points the attested stamper at the verification token
+await verifyOtp({ otpId, otpCode, otpEncryptionTargetBundle });
+await httpClient.approveActivity({ fingerprint, organizationId }, StamperType.Attested);
+```
+
+OAuth, where `onOauthSuccess` hands back the token instead of logging the user in:
+
+```ts
+await handleGoogleOauth({
+  onOauthSuccess: async ({ oidcToken, publicKey }) => {
+    await overrideAttestedStamper({ oidcToken, publicKey });
+    await httpClient.approveActivity({ fingerprint, organizationId }, StamperType.Attested);
+  },
+});
+```
+
+### How the stamp is attributed
+
+An attested stamp carries no user id: Turnkey resolves the user from the token, inside the organization the activity targets. Verification tokens match on **contact**, so the email or phone must be the one on the user. OIDC tokens match on `(sub, aud, iss)`, so a token from a different OAuth client will not match the same person.
+
+Attested stamps only work against sub-organizations. The same mechanism decides who a **login** belongs to: stamped in the browser it is the end user, so their MFA policies apply; stamped by your backend or the Auth Proxy with a parent-organization API key it is that parent user, and they do not.
 
 ## MFA and consensus
 

--- a/features/authentication/mfa/satisfying-mfa.mdx
+++ b/features/authentication/mfa/satisfying-mfa.mdx
@@ -18,6 +18,14 @@ The credential used to stamp this approval request determines which authenticati
 
 You can learn more about stamps [here](/api-reference/overview/stamps).
 
+### One approval per outstanding step
+
+Each `APPROVE_ACTIVITY` proves one authentication method. A policy with two steps therefore takes one approval, because the credential that stamped the original activity already proves the first step, and a policy with three steps takes two.
+
+The activity stays in `ACTIVITY_STATUS_AUTHENTICATORS_NEEDED` after each approval until every step has been satisfied, so treat this as a loop rather than a single challenge and response. Keep submitting approvals against the same `fingerprint`, each stamped with a different credential, until the activity leaves that status.
+
+Nothing is consumed along the way. Turnkey checks each step against everything the user has presented so far, which is why the same credential cannot satisfy two steps.
+
 ## API key
 
 To prove API key authentication, the user stamps the `APPROVE_ACTIVITY` request with an API key.
@@ -34,11 +42,13 @@ If the MFA policy specifies an `id`, the user must stamp with that specific auth
 
 To prove session authentication, the user stamps the `APPROVE_ACTIVITY` request with a session credential. A session credential is an API key that was classified as a session after a login activity (e.g., `STAMP_LOGIN`, `OTP_LOGIN`).
 
-If the MFA policy specifies an `id` for a session authentication method, the `id` refers to a [session profile](../sessions/session-profiles) ID. The user must stamp with a session credential that was issued with that specific session profile.
+If the MFA policy specifies an `id` for a session authentication method, the `id` refers to a [session profile](../sessions/session-profiles) ID. The user must stamp with a session credential that was issued with that specific session profile. If the `id` is the all-zero UUID, the opposite applies: only a session with no profile attached satisfies it, so a scoped session will not.
 
 Note that sessions are **not transitive**. For example, if a passkey was used to create a session, and an MFA policy requires `AUTHENTICATION_TYPE_PASSKEY`, the session **will not** satisfy that requirement. The user must stamp directly with the passkey.
 
-The same applies to logins that used an OTP or OAuth. A session obtained by signing in with Google presents as `AUTHENTICATION_TYPE_SESSION`, never `AUTHENTICATION_TYPE_OAUTH`, so a policy requiring OAuth sends the user back through the provider for a fresh OIDC token. Only an attested stamp presents `AUTHENTICATION_TYPE_OAUTH`, `AUTHENTICATION_TYPE_EMAIL_OTP` or `AUTHENTICATION_TYPE_SMS_OTP`.
+The same is true of OTP and OAuth logins. If the user signed in with Google, the session they received counts as `AUTHENTICATION_TYPE_SESSION` and nothing else. It does not count as `AUTHENTICATION_TYPE_OAUTH`. A policy requiring OAuth will therefore ask them to sign in with Google again, this time to produce a token used to approve the activity rather than to log in.
+
+Email OTP, SMS OTP and OAuth are only ever proven with an attested stamp, described in the next section.
 
 ## Email OTP, SMS OTP, and OAuth
 
@@ -50,26 +60,23 @@ Only OAuth authenticators support the `id` field in MFA policies. If specified, 
 
 ### Obtaining the attested stamp
 
-Both token types come from a flow the user completes in the browser, and both are bound to a key the client generates.
+Both token types come from a flow the user completes in the browser, and both are bound to a key the client generates. The examples below use `@turnkey/core`.
 
-Email or SMS OTP:
+For email or SMS OTP, `verifyOtp` points the attested stamper at the resulting verification token:
 
 ```ts
-// verifyOtp points the attested stamper at the verification token
 await verifyOtp({ otpId, otpCode, otpEncryptionTargetBundle });
 await httpClient.approveActivity({ fingerprint, organizationId }, StamperType.Attested);
 ```
 
-OAuth, where `onOauthSuccess` hands back the token instead of logging the user in:
+For OAuth, obtain an OIDC token from the provider using the same flow your application uses for sign-in, then point the stamper at it:
 
 ```ts
-await handleGoogleOauth({
-  onOauthSuccess: async ({ oidcToken, publicKey }) => {
-    await overrideAttestedStamper({ oidcToken, publicKey });
-    await httpClient.approveActivity({ fingerprint, organizationId }, StamperType.Attested);
-  },
-});
+await overrideAttestedStamper({ oidcToken, publicKey });
+await httpClient.approveActivity({ fingerprint, organizationId }, StamperType.Attested);
 ```
+
+If you are using `@turnkey/react-wallet-kit`, `handleGoogleOauth` runs the provider flow for you and returns the token through its `onOauthSuccess` callback, rather than logging the user in.
 
 ### How the stamp is attributed
 


### PR DESCRIPTION
Clarify MFA evaluation, attested stamps, and the recovery flow
Documents that MFA is evaluated for the user whose credential stamped the request, not the user the activity is about. This is what decides whether a sub-organization user's policies apply at login, and it was previously unstated.

- overview: new section on who is evaluated; state that MFA applies to root users and why; warn that listing the same method in two steps is one factor,  not two; document that a policy the user cannot satisfy is rejected at creation, with the per-type requirements table.
- satisfying-mfa: how to obtain an attested stamp for OTP and OAuth, how the stamp is attributed, and that a session never presents as OAuth or OTP.
- enforcement-and-recovery: correct the recovery steps so the browser stamps the login rather than the backend, add the challenge step, and warn that the second factor must differ from the one the login stamp carries. Rewrite the  design rationale as delay and detection rather than a boundary.
- examples: warn that the delegated-access protective policy needs order 0.