### PR TITLE
Add SDK reference implementation to MFA recovery page

### DIFF
--- a/features/authentication/mfa/enforcement-and-recovery.mdx
+++ b/features/authentication/mfa/enforcement-and-recovery.mdx
@@ -63,6 +63,10 @@ prohibits them).
 
 ### Recovery through new authenticator enrollment
 
+<Note>
+  **Reference implementation:** See the [with-mfa-and-scoped-sessions](https://github.com/tkhq/sdk/tree/main/examples/demos/with-mfa-and-scoped-sessions) SDK example for a complete end-to-end implementation of this pattern.
+</Note>
+
 This approach lets users regain access by proving identity through a strong, secondary channel
 (email + SMS OTP), then immediately enrolling a new passkey. The new credential is scoped to a
 recovery session that can only complete registration. It cannot sign, export, or perform other


### PR DESCRIPTION
Adds a prominent reference to the `with-mfa-and-scoped-sessions` SDK example on the MFA & Recovery page.

## Changes

Added a Note callout at the top of the "Recovery through new authenticator enrollment" section linking to the SDK example at https://github.com/tkhq/sdk/tree/main/examples/demos/with-mfa-and-scoped-sessions.

## Context

The DSE team built a full end-to-end reference implementation demonstrating the recovery-scoped-session pattern with MFA. This gives developers a working example to reference alongside the conceptual guidance on the docs page.
